### PR TITLE
Add @danielrsilver to Contributors List

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -3,3 +3,4 @@
 Thomas Siller (@silltho)
 @OogieBoogieInJSON
 @redagavin
+@danielrsilver

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -145,7 +145,7 @@
     "description": "The context menu entry shown for generating QR codes from a selected link."
   },
   "contextMenuItemOptions": {
-    "message": "Settings",
+    "message": "Manage Extension",
     "description": "The context menu entry shown for opening the settings."
   },
   "contextMenuSaveImage": {


### PR DESCRIPTION
Corrected the Settings menu name to "Manage Extension" in accordance with Firefox 62 update.

https://github.com/rugk/offline-qr-code/issues/119