### PR TITLE
Have removed the 'Settings' option in the Context Menu

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -144,10 +144,6 @@
     "message": "QR code from link",
     "description": "The context menu entry shown for generating QR codes from a selected link."
   },
-  "contextMenuItemOptions": {
-    "message": "Settings",
-    "description": "The context menu entry shown for opening the settings."
-  },
   "contextMenuSaveImage": {
     "message": "Save QR code…",
     "description": "The context menu entry shown for saving SVG images in the popup."

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -70,11 +70,6 @@ function createItems() {
         contexts: ["link"]
     }, onCreated);
 
-    browser.menus.create({
-        id: OPEN_OPTIONS,
-        title: browser.i18n.getMessage("contextMenuItemOptions"),
-        contexts: ["browser_action"]
-    }, onCreated);
 }
 
 /**


### PR DESCRIPTION
Issue #119 

Removed the Settings menu from the Context Menu as it is redundant in the latest version of firefox.

**Edit:** (by @rugk) Fixes #119