### PR TITLE
Add Turkish language support

### DIFF
--- a/assets/texts/tr/Changelog/1.1.html
+++ b/assets/texts/tr/Changelog/1.1.html
@@ -1,0 +1,12 @@
+<ul>
+<li><strong>Öne çıkan:</strong> Artık QR kod boyutunu elle veya otomaik olarak kaydedebilirsin.</li>
+<li><strong>Yeni:</strong> Araç çubuğu ikon rengi otomatik olarak belirlenir.</li>
+<li><strong>Yeni:</strong> Renkli araç çubuğu ikonu.</li>
+<li><strong>Yeni:</strong> Mobil uyumluluk geliştirmeleri.</li>
+<li><strong>Yeni:</strong> Hata ayıklama çıktısını etkinleştirme seçeneği.</li>
+<li><strong>Hata düzeltme:</strong> Açılır pencerenin boyutunu değiştirmek artık daha sorunsuz.</li>
+<li><strong>Hata düzeltme:</strong> Açılır pencerede bütün metin silindiğinde gösterilen gri QR kod normaliyle aynı boyutta.</li>
+<li><strong>Arka plan geliştirmesi:</strong> Daha tutarlı kod stili için linter kütüphanesi entegre edildi.</li>
+</ul>
+
+Daha fazla bilgiyi <a href="https://github.com/rugk/offline-qr-code/releases/tag/1.1">GitHub adresinde</a> bulabilirsin.

--- a/assets/texts/tr/Changelog/1.1.md
+++ b/assets/texts/tr/Changelog/1.1.md
@@ -1,0 +1,8 @@
+* **Öne çıkan:** Artık QR kod boyutunu elle veya otomaik olarak kaydedebilirsin.
+* **Yeni:** Araç çubuğu ikon rengi otomatik olarak belirlenir.
+* **Yeni:** Renkli araç çubuğu ikonu.
+* **Yeni:** Mobil uyumluluk geliştirmeleri.
+* **Yeni:** Hata ayıklama çıktısını etkinleştirme seçeneği.
+* **Hata düzeltme:** Açılır pencerenin boyutunu değiştirmek artık daha sorunsuz.
+* **Hata düzeltme:** Açılır pencerede bütün metin silindiğinde gösterilen gri QR kod normaliyle aynı boyutta.
+* **Arka plan geliştirmesi:** Daha tutarlı kod stili için linter kütüphanesi entegre edildi.

--- a/assets/texts/tr/Changelog/1.2.1.html
+++ b/assets/texts/tr/Changelog/1.2.1.html
@@ -1,0 +1,5 @@
+<ul>
+<li><strong>Hata düzeltme:</strong> QR kod boyutunu hatırlama özelliği düzeltildi.</li>
+</ul>
+
+Daha fazla bilgiyi <a href="https://github.com/rugk/offline-qr-code/releases/tag/1.2.1">GitHub adresinde</a> bulabilirsin.

--- a/assets/texts/tr/Changelog/1.2.1.md
+++ b/assets/texts/tr/Changelog/1.2.1.md
@@ -1,0 +1,1 @@
+* **Hata düzeltme:** QR kod boyutunu hatırlama özelliği düzeltildi.

--- a/assets/texts/tr/Changelog/1.2.html
+++ b/assets/texts/tr/Changelog/1.2.html
@@ -1,0 +1,15 @@
+<ul>
+<li><strong>Öne çıkan:</strong> <a href="https://github.com/rugk/offline-qr-code/blob/master/assets/screencasts/qrMenuFromPhoneNumber.gif">Seçili bir metinden veya linkten QR kod üretebilirsin.</a></li>
+<li><strong>Yeni:</strong> Seçeneklere hızlıca erişim için ikona sağ tıklayabilirsin.</li>
+<li><strong>Yeni:</strong> QR kod üretmek için kısayolu (Ctrl+Shift+F10) kullanabilirsin.</li>
+<li><strong>Yeni:</strong> QR kodlarını SVG olarak üretebilme özelliği eklendi.</li>
+<li><strong>Yeni:</strong> Sayfada seçili metinden otomatik olarak QR kod üretebilirsin.</li>
+<li><strong>Yeni:</strong> Rastgele ipuçları gösterme desteği eklendi.</li>
+<li><strong>Yeni:</strong> Düşük kontrast renk seçeneği için uyarı eklendi.</li>
+<li><strong>İyileştirme:</strong> Seçenekleri sıfırlama özelliği için "Geri al" butonu eklendi.</li>
+<li><strong>İyileştirme:</strong> Bazı mesajlar kapatılabilir.</li>
+<li><strong>İyileştirme:</strong> Eklenti ayarları sayfası artık Firefoc Photon Dizayn stili ile uyumlu hale getirildi.</li>
+<li><strong>Arka plan geliştirmesi:</strong> CSS değiskenleri kullanılmaya başlandı.</li>
+</ul>
+
+Daha fazla bilgiyi <a href="https://github.com/rugk/offline-qr-code/releases/tag/1.2">GitHub adresinde</a> bulabilirsin.

--- a/assets/texts/tr/Changelog/1.2.md
+++ b/assets/texts/tr/Changelog/1.2.md
@@ -1,0 +1,11 @@
+* **Öne çıkan:** [Seçili bir metinden veya linkten QR kod üretebilirsin.](https://github.com/rugk/offline-qr-code/blob/master/assets/screencasts/qrMenuFromPhoneNumber.gif)
+* **Yeni:** Seçeneklere hızlıca erişim için ikona sağ tıklayabilirsin.
+* **Yeni:** QR kod üretmek için kısayolu (Ctrl+Shift+F10) kullanabilirsin.
+* **Yeni:** QR kodlarını SVG olarak üretebilme özelliği eklendi.
+* **Yeni:** Sayfada seçili metinden otomatik olarak QR kod üretebilirsin.
+* **Yeni:** Rastgele ipuçları gösterme desteği eklendi.
+* **Yeni:** Düşük kontrast renk seçeneği için uyarı eklendi.
+* **İyileştirme:** Seçenekleri sıfırlama özelliği için "Geri al" butonu eklendi.
+* **İyileştirme:** Bazı mesajlar kapatılabilir.
+* **İyileştirme:** Eklenti ayarları sayfası artık Firefoc Photon Dizayn stili ile uyumlu hale getirildi.
+* **Arka plan geliştirmesi:** CSS değiskenleri kullanılmaya başlandı.

--- a/assets/texts/tr/amoDescription.html
+++ b/assets/texts/tr/amoDescription.html
@@ -1,0 +1,42 @@
+QR kod oluşturmak için Google Web API kullanan diğer birçok eklentinin aksine, bu eklenti tamamen çevrimdışı çalışır. <b>Bu QR kod üretecisi için gizliliğin birinci planda!</b>
+Bu eklenti gizliliğini korumak için tamamen <em>çevrimdışı</em> olarak senin bilgisayarında çalışır, hiç bir internet bağlantısına ihtiyaç duymaz ve her zaman da bu şekilde çalışmaya devam edecek.
+
+<br><b>Tek tıkla QR kod yaratabilirsin!</b><br>
+
+<b>Sade ama kullanışlı</b> kullanıcı arayüzü sayesinde bu eklentiyi ihtiyaçlarınıza göre ayarlayabileceğiniz birçok detayı ayarlarda bulabilirsin. Fakat bu kadar detaya rağmen kullanımı çok basit! Örneğin, fare ile sürükle-bırak yaparak QR kodu kolayca <b>yeniden boyutlandırabilirsin</b>. Ayrıca <b>küçük boyutlu</b> olması sebebiyle mobil bağlantılarda bile kurulumu kolay ve hızlı.
+
+Bu eklenti, Firefox 56 ve daha altındaki sürümler için tasarlanan <a href="https://github.com/catholicon/OfflineQR">eski QR kod üretecisi eklentisinden</a> esinlenilmiştir.
+
+<br><b>Birçok farklı şekilde QR kod üretebilirsin!</b><br>
+
+Bu eklentiyle <b>Renkli</b> QR kod üretebilir, herhangi bir QR kodunu <b>kaydedebilirsin</b>. Ya da sadece bir sekmeyi veya metni masaüstü bilgisayarından telefonuna göndermek için de kullanabilirsin. Seçim senin!
+QR kodun <b>bir tık uzağında</b> ve QR kodu metnini değiştirmek için tek yapman gereken yeni metni girmek.
+
+<br><b>Diğer özellikler</b><br>
+<ul>
+<li>Gizliliğin her zaman birinci öncelik. Bu sebeple QR kodun hiçbir internet bağlantısına ihtiyaç olmadan tamamen senin bilgisayarında üretilir.</li>
+<li>Firefox tarayıcısına doğal bir şekilde entegre olabilmek için <a href="https://design.firefox.com/photon/welcome.html">Firefox Photon Dizayn</a> sistemini kullanır.</li>
+<li>Kullanımı çok basit!</li>
+<li>Güncel ve uyarlanabilir <a href="https://github.com/nayuki/QR-Code-generator">QR kod</a> <a href="https://larsjung.de/kjua/">kütüphaneleri</a> kullanır.</li>
+<li>Ürettiğin QR kodlarını SVG veya PNG imaj (Canvas) olarak kaydedebilirsin.</li>
+<li>QR kodun boyutunu, rengini ve görünüşünü ayarlayabilirsin.</li>
+<li>QR kod oluşturmak için kısayol (Ctrl+Shift+F10) kullanabilirsin.</li>
+<li>Web sitesindeki seçili bir metinden QR kod oluşturabilirsin.</li>
+<li>Eksiksiz Unicode/UTF-8/Emoji desteği.</li>
+<li>Masaüstü ve mobil uyumlu görünüm ile her boyutta düzgün görünür.</li>
+<li>İngilizce, Almance ve Türkçe dillerinde kullanılabilir. <a href="https://github.com/rugk/offline-qr-code/blob/master/CONTRIBUTING.md#translations">Kendi dilini buradan ekle!</a></li>
+<li>Android için Firefox ile uyumlu</li>
+<li>Ayarların cihazların arasında senkronize edilir.</li>
+<li>Ayarlar sistem yöneticin tarafından ayarlanabilir. (henüz yapım aşamasında)</li>
+</ul>
+
+<br><b>Geliştirme</b><br>
+Bu eklenti açık kaynak bir yazılımdır ve GitHub üzerinde geliştirilmesi yapılmaktadır. <a href="https://github.com/rugk/offline-qr-code">Github'da fork'layarak</a> katkıda bulunabilirsin.
+<a href="https://github.com/rugk/offline-qr-code/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22">Kolay birkaç iş ile başlayabilirsin.</a>
+
+<br><b>İzinler</b><br>
+Bu eklenti mümkün mertebe en az izin ile çalışmaktadır.
+Bu eklentinin çalışması için gereken bütün izinlerin açıklamaları <a href="https://github.com/rugk/offline-qr-code/blob/master/assets/texts/en/permissions.md">bu adreste</a> yer almaktadır.
+
+<br><b>Notlar</b><br>
+“QR Kodu" DENSO WAVE firmasına patentlidir.

--- a/assets/texts/tr/amoScreenshots.csv
+++ b/assets/texts/tr/amoScreenshots.csv
@@ -1,0 +1,8 @@
+qrBig.png; "QR kodu yeniden boyutlandırılabilir!";
+qrDark.png; "QR kodu temana uyacak şekilde ayarlayabilirsin.";
+qrMenuFromLink.png; "Direkt olarak bir linkten QR kod üretebilirsin."
+qrMenuFromPhoneNumber.png; "Direkt olarak seçili metinden QR kod üretebilirsin."
+qrSave.png; "QR kodları SVG veya PNG olarak kaydedebilirsin.";
+qrSettings.png; "Davranışı ve görünüşü özelleştirebileceğin birçok seçenek mevcut.";
+qrSmall.png; "Herhangi bir boyutta QR kod üretebilirsin.";
+qrText.png; "QR kod üretmek için butona tıkladıktan sonra metni değiştirerek anında yeni bir QR kod yaratabilirsin.";

--- a/assets/texts/tr/amoSummary.txt
+++ b/assets/texts/tr/amoSummary.txt
@@ -1,0 +1,3 @@
+Bu eklentiyle açık sekmenin adresini veya herhangi bir seçili metni kullanarak çevrimdışı QR kod üretebilirsin.
+
+Gizliliğini korumak amacıyla tamamen çevrimdışı olarak çalışır. Buna rağmen, renkli QR kod üretme gibi birçok özelliği kullanabilirsin.

--- a/assets/texts/tr/permissions.md
+++ b/assets/texts/tr/permissions.md
@@ -1,0 +1,24 @@
+# Gerekli izinler
+
+Eklenti izinleriyle ilgili genel açıklama için [bu yazıya gözat](https://support.mozilla.org/kb/permission-request-messages-firefox-extensions).
+
+## Yüklenen izinler
+
+Kurulum ve güncelleme sırasında hiç bir izin talep edilmemektedir.
+
+## Özellik bazlı (opsiyonel) izinler
+
+Bu izinler bazı spesifik özellikleri kullanırken ihtiyaç duyulması halinde eklenti tarafından talep edilir.
+
+| Dahili Id   | İzin                                                                           | Talep eden                 | Açıklama                                                                                                                                                                                                       |
+|:------------|:-------------------------------------------------------------------------------|:---------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `downloads` | Dosya indirmek ve tarayıcının dosya indirme geçmişini görüntüleme ve düzenleme | QR kodu SVG olarak indirme | SVG dosyasını indirmek ve kullanıcıya dosyanın kaydedileceği yeri seçme imkanı sağlamak için gereklidir. Bu eklenti indirilmiş dosyalarınıza erişmez. Bu izni sadece indirme işlemini başlatmak için kullanır. |
+
+## Gizli izinler
+Bu eklenti ek olarak aşağıdaki izinleri de talep etmektedir. Bu izinler eklenti Firefox'a kurulurken kullanıcıdan talep edilmez çünkü bu izinler önemli izin olarak değerlendirilmemektedir.
+
+| Dahili Id   | İzin                         | Açıklama                                                                                |
+|:------------|:-----------------------------|:----------------------------------------------------------------------------------------|
+| `activeTab` | Güncel sekmeye erişim        | QR kod için aktif sekmenin adresine erişmek için gereklidir.                            |
+| `storage`   | Yerel depoya erişim          | Ayarları kaydetmek için gereklidir.                                                     |
+| `menus`     | Tarayıcı içerik menüsü       | "Seçili metinden QR kod üret" gibi seçenekleri içerik menüsüne eklemek için gereklidir. |

--- a/assets/texts/tr/privacy.txt
+++ b/assets/texts/tr/privacy.txt
@@ -1,0 +1,3 @@
+Bu eklenti hiç bir üçüncü partiye veya eklenti sahibine herhangi bir bilgi göndermemektedir.
+
+Bu eklentinin gerektirdiği bütün izinlere dair açıklamaya bu linkten ulaşılabilir: https://github.com/rugk/offline-qr-code/blob/master/assets/texts/en/permissions.md.

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -1,0 +1,288 @@
+{
+  // manifest.json
+  "extensionName": {
+    "message": "Çevrimdışı QR Kod Üreticisi",
+    "description": "Name of the extension."
+  },
+  "extensionNameShort": {
+    "message": "Çevrimdışı QR-Kod",
+    "description": "Name of the extension."
+  },
+  "extensionDescription": {
+    "message": "Tarayıcında açık olan herhangi bir sayfa veya sekme için QR kod oluşturmanı sağlar.",
+    "description": "Description of the extension."
+  },
+  "browserActionButtonTitle": {
+    "message": "Çevrimdışı QR Kod",
+    "description": "The title for the button, which opens the popup."
+  },
+
+  // errors or other messages
+  "unknownError": {
+    "message": "bilinmeyen hata",
+    "description": ""
+  },
+  "loading": {
+    "message": "Yükleniyor…",
+    "description": "A general loading message."
+  },
+  "messageUndoButton": {
+    "message": "Geri al",
+    "description": "The text of a button that undoes the last action."
+  },
+  "couldNotGenerateQrCode": {
+    "message": "QR Kod oluşturulamadı.",
+    "description": ""
+  },
+  "couldNotReceiveActiveTab": {
+    "message": "Aktif sekmeye ulaşılamadı.",
+    "description": ""
+  },
+  "errorShowingMessage": {
+    "message": "Mesaj görüntülenemedi.",
+    "description": "When there is an error when showing the error/info/…."
+  },
+  "errorDownloadingFile": {
+    "message": "Dosya indirilemedi.",
+    "description": "Error shown when a file could not be downloaded. Do not mention a file type or name, but just keep it general."
+  },
+  "errorPermissionRequired": {
+    "message": "Gerekli yetkiler olmadığı için işlem tamamlanamadı.",
+    "description": "Error shown when a permission is declined and the thing the user triggered cannot be executed."
+  },
+  "errorPermissionRequestFailed": {
+    "message": "Yetkilendirma hatası.",
+    "description": "Error shown when a permission request failed. This indicates a technical error and does NOT mean the user declined the permission."
+  },
+  "couldNotSaveOption": {
+    "message": "Ayarlar kaydedilemedi.",
+    "description": "When a setting could not be saved."
+  },
+  "couldNotLoadOptions": {
+    "message": "Ayarlar yüklenemedi.",
+    "description": "When one or all settings could not be loaded."
+  },
+  "couldNotUndoAction": {
+    "message": "Geri alma işlemi başarısız.",
+    "description": "Shown when an action cannot be undone."
+  },
+  "resettingOptionsWorked": {
+    "message": "Bütün ayarlar varsayılan değerlere döndürüldü!",
+    "description": "The message shown, when the options of the settings were reset."
+  },
+  "resettingOptionsFailed": {
+    "message": "Seçenekleri sıfırlama başarısız oldu!",
+    "description": "The message shown, when the options of the settings could not have been reset."
+  },
+  "requestDownloadPermissionForQr": {
+    "message": "QR kodu kaydedebilmek için dosya indirma izni gerekiyor.",
+    "description": "Shown, when the user is asked to allow the download permission to save the QR code."
+  },
+  "lowContrastRatioInfo": {
+    "message": "Düşük kontrast sebebiyle QR kodunuz bazı tarayıcılar tarafından zor okunabilir.",
+    "desription": "The message shown when the contrast ratio is too low"
+  },
+  "lowContrastRatioWarning": {
+    "message": "QR kodun kontrast oranı çok düşük olduğu için tüm QR okuyucular tarafından doğru okunamayabilir.",
+    "desription": "The warning shown when the contrast ratio is too low"
+  },
+  "lowContrastRatioError": {
+    "message": "QR kodun rengi ile arka plan rengi birbirine çok yakın.",
+    "description": "The message shown when the color for the QR code and the background are equal"
+  },
+  "messageAutoSelectColorButton": {
+    "message": "Zıt renkler kullan",
+    "description": "The text of a button that sets a new color with a sufficient contrast."
+  },
+
+  // tips
+  "tipYouLikeAddon": {
+    "message": "Eklentiyi beğendin mi?",
+    "description": "A tip shown to remind the user to rate the addon."
+  },
+  "tipYouLikeAddonButton": {
+    "message": "Eklentiyi puanla",
+    "description": "Button for the tip shown to remind the user to rate the addon."
+  },
+  "tipSaveQrCode": {
+    "message": "QR kodları kaydedebileceğini biliyor muydun?",
+    "description": "A tip shown to get the user to find the save option."
+  },
+  "tipQrCodeHotkey": {
+    "message": "Bu eklenti için kısayol Ctrl+Shift+F10.",
+    "description": "A tip shown to get the user to notice that there is a hot key."
+  },
+  "tipDonate": {
+    "message": "Bu eklentiyi ücretsiz olarak kullanmaktan memnun musun?",
+    "description": "A tip shown to get the remind them of a donation."
+  },
+  "tipDonateButton": {
+    "message": "Bağış yaparak destek olabilirsin.",
+    "description": "The button of the donation tip taking the user to the donation site."
+  },
+  "tipLearnMore": {
+    "message": "Daha fazla bilgi",
+    "description": "The common button for tips, where you can get more information on click."
+  },
+
+  // placeholder
+  "qrCodePlaceholder": {
+    "message": "QR kod için ayrılmış alan",
+    "description": "Alt text of placeholder image."
+  },
+  "textareaPlaceholder": {
+    "message": "QR kod için bir metin gir.",
+    "description": "Placeholder for the textarea, when it is empty."
+  },
+
+  // context menu
+  "contextMenuItemConvertSelection": {
+    "message": "Seçili kısımdan QR kod üret",
+    "description": "The context menu entry shown for generating QR codes from a selection."
+  },
+  "contextMenuItemConvertLinkSelection": {
+    "message": "Linkten QR kod üret",
+    "description": "The context menu entry shown for generating QR codes from a selected link."
+  },
+  "contextMenuSaveImage": {
+    "message": "QR kod kaydet…",
+    "description": "The context menu entry shown for saving SVG images in the popup."
+  },
+
+  // options
+  "someSettingsAreManaged": {
+    "message": "Bazı ayarlar sistem yöneticin tarafından düzenlendiği için değiştirilemez.",
+    "description": "The message, which appears, when settings are pre-defined (as managed options) by administrators."
+  },
+  "optionIsDisabledBecauseManaged": {
+    "message": "Bu özellik sistem yöneticin tarafından ayarlandığı için devredışı.",
+    "description": "The title (tooltip) shown, when hovering over a disabled, managed option."
+  },
+  "optionLearnMore": {
+    "message": "Daha fazla bilgi",
+    "description": "When a link to an explainer needs to be added, this is the link text."
+  },
+
+  "optionPopupIconColored": {
+    "message": "Renkli ikon",
+    "description": "This is an option shown in the add-on settings."
+  },
+  "optionPopupIconColoredDescr": {
+    "message": "Araç çubuğunda siyah beyaz ikon yerine renkli ikon gösterir.",
+    "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."
+  },
+
+  "optionQrCodeType": {
+    "message": "QR kod türü",
+    "description": "The heading/grouping title shown for the radio buttons for the type setting of the QR code."
+  },
+  "optionQrCodeTypeSvg": {
+    "message": "SVG",
+    "description": "Option to select a scalable vector graphic image (SVG)."
+  },
+  "optionQrCodeTypeSvgHelper": {
+    "message": "QR kod, daha düzgün yeniden boyutlandırma sağlayan vektör grafikler ile oluşturulur.",
+    "description": "Helper text for SVG QR code type option."
+  },
+  "optionQrCodeTypeCanvas": {
+    "message": "Canvas resmi",
+    "description": "Option to select a canvas (pixel) image."
+  },
+  "optionQrCodeTypeCanvasHelper": {
+    "message": "QR kod, imaj (\"canvas\") olarak oluşturulur.",
+    "description": "Helper text for canvas QR code type option."
+  },
+
+  "optionQrCodeSize": {
+    "message": "QR kod boyutu",
+    "description": "The heading/grouping title shown for the radio buttons for the size setting of the QR code."
+  },
+  "optionQrCodeSizeFixed": {
+    "message": "Sabit:",
+    "description": "This is an option shown in the add-on settings. It is one option for selecting the QR code size."
+  },
+  "optionPixelAbbreviation": {
+    "message": "px",
+    "description": "The abbreviation of the term 'pixels'. In most cases, it may stay as it is in English."
+  },
+  "optionQrCodeSizeAuto": {
+    "message": "Boyutu otomatik ayarla",
+    "description": "This is an option shown in the add-on settings. It is one option for selecting the QR code size."
+  },
+  "optionQrCodeSizeAutoHelper": {
+    "message": "QR kodunun yeni bir sekme açtığı mobil cihazlarda kullanışlıdır.",
+    "description": "Helper text for the optionQrCodeSizeAuto making the user aware that this setting will likely have no or little effect on desktop devices."
+  },
+  "optionQrCodeSizeRemember": {
+    "message": "Son kullanılan boyutu hatırla",
+    "description": "This is an option shown in the add-on settings. It is one option for selecting the QR code size."
+  },
+
+  "optionQrCodeColor": {
+    "message": "QR kodu rengi:",
+    "description": "This is an option shown in the add-on settings."
+  },
+
+  "optionQrCodeBackgroundColor": {
+    "message": "QR kodu arkaplan rengi:",
+    "description": "This is an option shown in the add-on settings."
+  },
+
+  "optionErrorCorrection": {
+    "message": "Hata düzeltme oranı:",
+    "description": "Error correction setting for QR code. See https://en.wikipedia.org/wiki/QR_code#Error_correction."
+  },
+  "optionEcLow": {
+    "message": "Düşük (7%)",
+    "description": "Option of error correction level for QR code. See https://en.wikipedia.org/wiki/QR_code#Error_correction."
+  },
+  "optionEcMedium": {
+    "message": "Orta (15%)",
+    "description": "Option of error correction level for QR code. See https://en.wikipedia.org/wiki/QR_code#Error_correction."
+  },
+  "optionEcQuartile": {
+    "message": "Çeyrek (%25)",
+    "description": "Option of error correction level for QR code. See https://en.wikipedia.org/wiki/QR_code#Error_correction."
+  },
+  "optionEcHigh": {
+    "message": "Yüksek (%30)",
+    "description": "Option of error correction level for QR code. See https://en.wikipedia.org/wiki/QR_code#Error_correction."
+  },
+  "optionErrorCorrectionDescr": {
+    "message": "Bu değer kodun ne kadarı eksik olsa bile yine de okunabileceğini gösterir.",
+    "description": "The description of the error correction option."
+  },
+  "optionErrorCorrectionDescrLink": {
+    "message": "https://en.wikipedia.org/wiki/QR_code#Error_correction",
+    "description": "The 'Learn more' link in the description of the error correction option."
+  },
+
+  "optionAutoGetSelectedText": {
+    "message": "Seçili metni QR kodu oluşturmak için kullan",
+    "description": "This is an option shown in the add-on settings."
+  },
+  "optionUseMonospaceFont": {
+    "message": "Eşaralıklı (monospace) yazıtipi kullan",
+    "description": "This is an option shown in the add-on settings."
+  },
+
+  "optionDebugMode": {
+    "message": "Hata ayıklama modunu etkinleştir",
+    "description": "This is an option shown in the add-on settings."
+  },
+  "optionDebugModeDescr": {
+    "message": "Hata tespiti için konsolda daha detaylı çıktı görmeye yarar.",
+    "description": "The description shown for the debug mode (optionDebugMode)."
+  },
+
+  "optionsResetButton": {
+    "message": "Bütün ayarları varsayılanlara sıfırla",
+    "description": "The button to delete all current settings and load the defaults, shown in the add-on settings."
+  },
+
+  // ARIA labels/descriptions
+  "dismissIconDescription": {
+    "message": "Bu mesajı kapat",
+    "description": "The label for the close button of the message box"
+  }
+}


### PR DESCRIPTION
I am not a professional translator but I thought this extension is cool. So, I decided to give it a try. However, not all technical terms have a matching expression in Turkish. I tried by best about those.

<img width="836" alt="screenshot 2018-10-28 at 14 16 54" src="https://user-images.githubusercontent.com/1936287/47616371-2be5fe00-dabc-11e8-95cc-5cc03c132cdd.png">
