### PR TITLE
Improved internalization of quiet zone option text near range slider.

### DIFF
--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -239,20 +239,20 @@
     "description": "This is an option shown in the add-on settings. It's about the area around the QR code."
   },
   "optionQrQuietZoneStatusSingular": {
-    "message": "$QRQUIETZONE$ Quadrat",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "message": "($INTEGER$ Quadrat)",
+    "description": "This is the number of empty/'white' modules around the QR code in its singular form.",
     "placeholders": {
-      "qrQuietZone": {
+      "integer": {
         "content": "$1",
         "example": "1"
       }
     }
   },
   "optionQrQuietZoneStatusPlural": {
-    "message": "$QRQUIETZONE$ Quadrate",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "message": "($INTEGER$ Quadrate)",
+    "description": "This is the number of empty/'white' modules around the QR code in its plural form.",
     "placeholders": {
-      "qrQuietZone": {
+      "integer": {
         "content": "$1",
         "example": "3"
       }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -238,9 +238,25 @@
     "message": "QR-Randzone („quiet zone“):",
     "description": "This is an option shown in the add-on settings. It's about the area around the QR code."
   },
-  "optionQrQuietZoneStatus": {
-    "message": "Quadrat(e)",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code."
+  "optionQrQuietZoneStatusSingular": {
+    "message": "$QRQUIETZONE$ Quadrat",
+    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "placeholders": {
+      "qrQuietZone": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "optionQrQuietZoneStatusPlural": {
+    "message": "$QRQUIETZONE$ Quadrate",
+    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "placeholders": {
+      "qrQuietZone": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "optionQrQuietZoneDescr": {
     "message": "Die Anzahl der in der Hintergrundfarbe gefärbten Randmodule um den QR-Code.",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -239,20 +239,20 @@
     "description": "This is an option shown in the add-on settings. It's about the area around the QR code."
   },
   "optionQrQuietZoneStatusSingular": {
-    "message": "$QRQUIETZONE$ square",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "message": "($INTEGER$ square)",
+    "description": "This is the number of empty/'white' modules around the QR code in its singular form.",
     "placeholders": {
-      "qrQuietZone": {
+      "integer": {
         "content": "$1",
         "example": "1"
       }
     }
   },
   "optionQrQuietZoneStatusPlural": {
-    "message": "$QRQUIETZONE$ squares",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "message": "($INTEGER$ squares)",
+    "description": "This is the number of empty/'white' modules around the QR code in its plural form.",
     "placeholders": {
-      "qrQuietZone": {
+      "integer": {
         "content": "$1",
         "example": "3"
       }

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -238,9 +238,25 @@
     "message": "QR quiet zone:",
     "description": "This is an option shown in the add-on settings. It's about the area around the QR code."
   },
-  "optionQrQuietZoneStatus": {
-    "message": "square(s)",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code."
+  "optionQrQuietZoneStatusSingular": {
+    "message": "$QRQUIETZONE$ square",
+    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "placeholders": {
+      "qrQuietZone": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "optionQrQuietZoneStatusPlural": {
+    "message": "$QRQUIETZONE$ squares",
+    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "placeholders": {
+      "qrQuietZone": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "optionQrQuietZoneDescr": {
     "message": "The number of border modules around the QR code colored in the background color.",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -234,9 +234,25 @@
     "message": "QR çerçevesi (quiet zone):",
     "description": "This is an option shown in the add-on settings. It's about the area around the QR code."
   },
-  "optionQrQuietZoneStatus": {
-    "message": "kare",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code."
+  "optionQrQuietZoneStatusSingular": {
+    "message": "$QRQUIETZONE$ kare",
+    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "placeholders": {
+      "qrQuietZone": {
+        "content": "$1",
+        "example": "1"
+      }
+    }
+  },
+  "optionQrQuietZoneStatusPlural": {
+    "message": "$QRQUIETZONE$ kareler",
+    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "placeholders": {
+      "qrQuietZone": {
+        "content": "$1",
+        "example": "3"
+      }
+    }
   },
   "optionQrQuietZoneDescr": {
     "message": "QR kod çevresinde renkli arkaplandan ayırmak için kullanılacak çerçevenin boyutu.",

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -235,20 +235,20 @@
     "description": "This is an option shown in the add-on settings. It's about the area around the QR code."
   },
   "optionQrQuietZoneStatusSingular": {
-    "message": "$QRQUIETZONE$ kare",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "message": "($INTEGER$ kare)",
+    "description": "This is the number of empty/'white' modules around the QR code in its singular form.",
     "placeholders": {
-      "qrQuietZone": {
+      "integer": {
         "content": "$1",
         "example": "1"
       }
     }
   },
   "optionQrQuietZoneStatusPlural": {
-    "message": "$QRQUIETZONE$ kareler",
-    "description": "This is an option shown in the add-on settings. It should name the empty/'white' modules around the QR code.",
+    "message": "($INTEGER$ kareler)",
+    "description": "This is the number of empty/'white' modules around the QR code in its plural form.",
     "placeholders": {
-      "qrQuietZone": {
+      "integer": {
         "content": "$1",
         "example": "3"
       }

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -91,13 +91,24 @@ function applyDebugMode(optionValue) {
  *
  * @function
  * @private
- * @param {string} optionValue
+ * @param {number} optionValue
  * @returns {void}
  */
 function updateQrQuietZoneStatus(optionValue) {
     const elQrQuietZoneStatus = document.getElementById("qrQuietZoneStatus");
+    let messageName = "optionQrQuietZoneStatusPlural";
 
-    elQrQuietZoneStatus.textContent = optionValue;
+    if (optionValue === 1) {
+        messageName = "optionQrQuietZoneStatusSingular";
+    }
+
+    const translatedMessage = browser.i18n.getMessage(messageName, optionValue);
+
+    if (!translatedMessage) {
+        throw new Error(`no translation string for "${messageName}" could be found`);
+    }
+
+    elQrQuietZoneStatus.textContent = translatedMessage;
 }
 
 /**

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -86,22 +86,41 @@ function applyDebugMode(optionValue) {
 }
 
 /**
+ * Gets the plural form of the quiet zone translation, depending on the option value.
+ *
+ * @function
+ * @private
+ * @param {string} language
+ * @param {integer} optionValue
+ * @returns {string} messageName
+ */
+function getPluralForm(language, optionValue) {
+    if (!language) {
+        language = 'en';
+    }
+
+    switch(language) {
+        case 'tr':
+            return optionValue > 1 ? "optionQrQuietZoneStatusPlural" : "optionQrQuietZoneStatusSingular";
+        //en, de
+        default:
+            return optionValue !== 1 ? "optionQrQuietZoneStatusPlural" : "optionQrQuietZoneStatusSingular";
+    }
+}
+
+/**
  * Adjust UI of QR code quiet zone status (the "N modules" text). Triggers once
  * after the options have been loaded and when the option value is updated by the user.
  *
  * @function
  * @private
- * @param {number} optionValue
+ * @param {integer} optionValue
  * @returns {void}
+ * @throws {Error} if no translation could be found
  */
 function updateQrQuietZoneStatus(optionValue) {
     const elQrQuietZoneStatus = document.getElementById("qrQuietZoneStatus");
-    let messageName = "optionQrQuietZoneStatusPlural";
-
-    if (optionValue === 1) {
-        messageName = "optionQrQuietZoneStatusSingular";
-    }
-
+    const messageName = getPluralForm(document.querySelector("html").getAttribute("lang"), optionValue);
     const translatedMessage = browser.i18n.getMessage(messageName, optionValue);
 
     if (!translatedMessage) {

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -110,10 +110,9 @@
 				</li>
 				<li>
 					<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
-					<input class="setting save-on-input" type="range" value="0" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
+					<input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
 					<span>
-						(<span id="qrQuietZoneStatus">0</span>
-						<span data-i18n="__MSG_optionQrQuietZoneStatus__">square(s)</span>)
+						(<span id="qrQuietZoneStatus">1 square</span>)
 					</span>
 					<span class="helper-text">
 						<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -112,7 +112,7 @@
 					<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
 					<input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
 					<span>
-						(<span id="qrQuietZoneStatus">1 square</span>)
+						<span id="qrQuietZoneStatus">(1 square)</span>
 					</span>
 					<span class="helper-text">
 						<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>


### PR DESCRIPTION
Added singular/plural versions of each language with a placeholder for the quiet zone value. Then used JavaScript to determine the correct version. Languages that have different word orders can just move the placeholder to the appropriate location.