### PR TITLE
Change Firefox Photon dead link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ See:
 
 ## Features
 * Puts your privacy first! Privacy is the default here, so it is generating QR codes offline.
-* Follows [Firefox Photon Design](https://design.firefox.com/photon/welcome.html).
+* Follows [Firefox Photon Design](https://design.firefox.com/photon/).
 * Has a simple, but intuitive and usable User Interface.
 * Uses up-to-date, great and customizable [QR code](https://github.com/nayuki/QR-Code-generator) [libraries](https://larsjung.de/kjua/).
 * You can generate and save QR codes as SVG or Canvas (PNG image)!

--- a/assets/texts/de/amoDescription.html
+++ b/assets/texts/de/amoDescription.html
@@ -18,7 +18,7 @@ Dein QR-Code wird immer nur <b>einen Klick weg sein</b> und du kannst sofort anf
 <b>Weitere Features</b>
 <ul>
 <li>Setzt deine Privatsphäre an erste Stelle! Privatsphäre wird hier standardmäßig angewendet, also generiert dass Add-on QR-Codes ohne Internetverbindung.</li>
-<li>Folgt den <a href="https://design.firefox.com/photon/welcome.html">Firefox-Photon-Design</a>-Guidelines um sich reibungslos in das Design deines Firefox zu integrieren.</li>
+<li>Folgt den <a href="https://design.firefox.com/photon/">Firefox-Photon-Design</a>-Guidelines um sich reibungslos in das Design deines Firefox zu integrieren.</li>
 <li>Ist super einfach und intuitiv benutzbar!</li>
 <li>Benutzt aktuelle, großartige und anpassbare <a href="https://github.com/nayuki/QR-Code-generator">QR-Code</a>-<a href="https://larsjung.de/kjua/">Bibliotheken</a> zum Generieren der QR-Codes.</li>
 <li>Du kannst QR-Codes im SVG-Format oder als PNG-Bild (Canvas) generieren und speichern!</li>

--- a/assets/texts/en/amoDescription.html
+++ b/assets/texts/en/amoDescription.html
@@ -17,7 +17,7 @@ Your QR code will only be <b>one click away</b> and you can instantly start typi
 <b>More features</b>
 <ul>
 <li>Puts your privacy first! Privacy is the default here, so it is generating QR codes offline.</li>
-<li>Follows <a href="https://design.firefox.com/photon/welcome.html">Firefox Photon Design</a> to integrate smoothly into the design of your Firefox.</li>
+<li>Follows <a href="https://design.firefox.com/photon/">Firefox Photon Design</a> to integrate smoothly into the design of your Firefox.</li>
 <li>It's super simple and intuitive usable!</li>
 <li>Uses up-to-date, great, and customizable <a href="https://github.com/nayuki/QR-Code-generator">QR code</a> <a href="https://larsjung.de/kjua/">libraries</a> to generate the QR codes.</li>
 <li>You can generate and save QR codes as SVG or PNG images (Canvas)!</li>

--- a/assets/texts/tr/amoDescription.html
+++ b/assets/texts/tr/amoDescription.html
@@ -18,7 +18,7 @@ QR kodun <b>bir tık uzağında</b>. Tıkladıkdan sonra ise QR kodu değiştirm
 <b>Diğer özellikler</b>
 <ul>
 <li>Gizliliğin her zaman birinci öncelik. Bu sebeple QR kodun hiçbir internet bağlantısına ihtiyaç olmadan tamamen senin bilgisayarında üretilir.</li>
-<li>Firefox tarayıcısına doğal bir şekilde entegre olabilmek için <a href="https://design.firefox.com/photon/welcome.html">Firefox Photon Dizayn</a> sistemini kullanır.</li>
+<li>Firefox tarayıcısına doğal bir şekilde entegre olabilmek için <a href="https://design.firefox.com/photon/">Firefox Photon Dizayn</a> sistemini kullanır.</li>
 <li>Kullanımı çok basit!</li>
 <li>Güncel ve uyarlanabilir <a href="https://github.com/nayuki/QR-Code-generator">QR kod</a> <a href="https://larsjung.de/kjua/">kütüphaneleri</a> kullanır.</li>
 <li>Ürettiğin QR kodlarını SVG veya PNG imaj (Canvas) olarak kaydedebilirsin.</li>


### PR DESCRIPTION
Fixes the dead link to the Firefox website as of issue #154 