### PR TITLE
Adjust and group options style with headers like Firefox #43

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -197,7 +197,7 @@
     "description": "The message, which appears, when settings are pre-defined (as managed options) by administrators."
   },
   "titleGeneral": {
-    "message": "General Settings",
+    "message": "Add On",
     "description": "The title for the general settings group."
   },
   "titleQrCodeSetting": {
@@ -221,10 +221,6 @@
     "description": "The button to delete all current settings and load the defaults, shown in the add-on settings."
   },
 
-  "subtitlePopupIconColored": {
-    "message": "Colored icon",
-    "description": "This is a sub heading in the add-on settings."
-  },
   "optionPopupIconColoredDescr": {
     "message": "Shows a colored icon instead of the black/white icon in the toolbar.",
     "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -201,11 +201,11 @@
     "description": "The title for the general settings group."
   },
   "titleQrCodeSetting": {
-    "message": "QR Code",
+    "message": "QR code",
     "description": "The title for the qr code settings group."
   },
   "titleAddonBehavior": {
-    "message": "Add-on Behavior",
+    "message": "Add-on behavior",
     "description": "The title for the addon behavior settings group."
   },
   "optionIsDisabledBecauseManaged": {
@@ -277,7 +277,7 @@
   },
 
   "subtitleMisc": {
-    "message": "Miscellaneous Settings",
+    "message": "Miscellaneous settings",
     "description": "The heading/grouping title shown for the miscellaneous setting of the QR code."
   },
   "optionQrQuietZone": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -221,16 +221,16 @@
     "description": "The button to delete all current settings and load the defaults, shown in the add-on settings."
   },
 
-  "optionPopupIconColored": {
+  "subtitlePopupIconColored": {
     "message": "Colored icon",
-    "description": "This is an option shown in the add-on settings."
+    "description": "This is a sub heading in the add-on settings."
   },
   "optionPopupIconColoredDescr": {
     "message": "Shows a colored icon instead of the black/white icon in the toolbar.",
     "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."
   },
 
-  "optionQrCodeType": {
+  "subtitleQrCodeType": {
     "message": "QR code type",
     "description": "The heading/grouping title shown for the radio buttons for the type setting of the QR code."
   },
@@ -251,13 +251,9 @@
     "description": "Helper text for canvas QR code type option."
   },
 
-  "optionQrCodeSize": {
+  "subtitleQrCodeSize": {
     "message": "QR code size",
     "description": "The heading/grouping title shown for the radio buttons for the size setting of the QR code."
-  },
-  "optionMisc": {
-    "message": "Miscellaneous Settings",
-    "description": "The heading/grouping title shown for the miscellaneous setting of the QR code."
   },
   "optionQrCodeSizeFixed": {
     "message": "Fixed size:",
@@ -280,6 +276,10 @@
     "description": "This is an option shown in the add-on settings. It is one option for selecting the QR code size."
   },
 
+  "subtitleMisc": {
+    "message": "Miscellaneous Settings",
+    "description": "The heading/grouping title shown for the miscellaneous setting of the QR code."
+  },
   "optionQrQuietZone": {
     "message": "QR quiet zone:",
     "description": "This is an option shown in the add-on settings. It's about the area around the QR code."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -221,6 +221,10 @@
     "description": "The button to delete all current settings and load the defaults, shown in the add-on settings."
   },
 
+  "optionPopupIconColored": {
+    "message": "Colored icon",
+      "description": "This is an option shown in the add-on settings."
+  },
   "optionPopupIconColoredDescr": {
     "message": "Shows a colored icon instead of the black/white icon in the toolbar.",
     "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -196,6 +196,18 @@
     "message": "Some settings are managed by your system administrator and cannot be changed.",
     "description": "The message, which appears, when settings are pre-defined (as managed options) by administrators."
   },
+  "titleGeneral": {
+    "message": "General Settings",
+    "description": "The title for the general settings group."
+  },
+  "titleQrCodeSetting": {
+    "message": "QR Code Settings",
+    "description": "The title for the qr code settings group."
+  },
+  "titleAddonBehavior": {
+    "message": "Addon Behavior",
+    "description": "The title for the addon behavior settings group."
+  },
   "optionIsDisabledBecauseManaged": {
     "message": "This option is disabled, because it has been configured by your system administrator.",
     "description": "The title (tooltip) shown, when hovering over a disabled, managed option."
@@ -242,6 +254,10 @@
   "optionQrCodeSize": {
     "message": "QR code size",
     "description": "The heading/grouping title shown for the radio buttons for the size setting of the QR code."
+  },
+  "optionMisc": {
+    "message": "Miscellaneous Settings",
+    "description": "The heading/grouping title shown for the miscellaneous setting of the QR code."
   },
   "optionQrCodeSizeFixed": {
     "message": "Fixed size:",

--- a/src/common/common.css
+++ b/src/common/common.css
@@ -135,7 +135,7 @@ a:active {
   border-radius: 4px;
 
   /* use whole width */
-  width: 100%;
+  width: calc(100% - 8px);
   min-height: 32px;
 
   /* make errors selectable, so users can copy them */

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -19,10 +19,6 @@ body.mobile .mobile-incompatible {
   opacity: 0.4;
 }
 
-form {
-  margin: 16px 32px;
-}
-
 section {
   margin-bottom: 32px;
 }
@@ -46,6 +42,7 @@ h1 {
 
 form section:first-child h1 {
   border-top: none;
+  margin-top: 16px;
 }
 
 h2{

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,7 +1,6 @@
 body {
-  color: #333;
-  font-family: sans-serif;
-  font-size: 14px;
+  /* body20 */
+  font-size: 15px;
 }
 
 /* on (small) mobile displays */
@@ -28,9 +27,10 @@ h1 {
   margin: 0;
   padding: 16px 0;
 
+  /* title30 */
+  font-size: 22px;
   border-top: 1px solid rgba(12, 12, 13, 0.15);
   font-weight: 300;
-  font-size: 1.46em;
 }
 
 h1:first-child {
@@ -38,9 +38,10 @@ h1:first-child {
 }
 
 h2{
+  /* title20 */
+  font-size: 17px;
   margin-bottom: 4px;
   font-weight: 600;
-  font-size: 1.14em;
 }
 
 ul {
@@ -63,6 +64,7 @@ li {
 }
 
 .item .line * {
+  /* https://design.firefox.com/photon/visuals/grid.html#spacing */
   margin: 0 8px 0 0;
 }
 
@@ -71,6 +73,8 @@ li {
 }
 
 .helper-text {
+  /* caption20 */
+  font-size: 13px;
   color: var(--grey-50);
 }
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,3 +1,7 @@
+:root {
+  --gray: rgba(12, 12, 13, 0.15);
+}
+
 body {
   /* body20 */
   font-size: 15px;
@@ -27,7 +31,7 @@ section {
 hr {
   border: 0;
   height: 1px;
-  background-color: rgba(12, 12, 13, 0.15);
+  background-color: var(--gray);
 }
 
 h1 {
@@ -38,7 +42,7 @@ h1 {
   font-size: 22px;
   font-weight: 300;
 
-  border-top: 1px solid rgba(12, 12, 13, 0.15);
+  border-top: 1px solid var(--gray);
 }
 
 form section:first-child h1 {

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -37,14 +37,21 @@ h1:first-child {
   border-top: none;
 }
 
-section {
-  margin-bottom: 32px;
-}
-
 h2{
   margin-bottom: 4px;
   font-weight: 600;
   font-size: 1.14em;
+}
+
+ul {
+  padding: 0;
+  margin-bottom: 32px;
+}
+
+li {
+  list-style-type: none;
+  margin-top: 10px;
+  padding: 0px;
 }
 
 .line {

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -23,9 +23,13 @@ form {
   margin: 16px 32px;
 }
 
+section {
+  margin-bottom: 32px;
+}
+
 h1 {
-  margin: 0;
-  padding: 16px 0;
+  margin: 32px 0 0 0;
+  padding: 16px 0 0 0;
 
   /* title30 */
   font-size: 22px;
@@ -41,20 +45,20 @@ h1.first {
 h2{
   /* title20 */
   font-size: 17px;
-  margin-bottom: 4px;
   font-weight: 600;
+  margin-top: 32px;
 }
 
 ul {
+  margin: 0;
   padding: 0;
-  margin-bottom: 32px;
 }
 
 li {
   list-style-type: none;
 
   padding: 2px 0;
-  margin: 10px 0 4px 0;
+  margin: 0 0 4px 0;
 
   display: flex;
   align-items: center;

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -42,7 +42,7 @@ h1 {
   font-size: 22px;
   font-weight: 300;
 
-  border-top: 1px solid var(--gray);
+  border-top: 1px solid var(--gray-separator);
 }
 
 form section:first-child h1 {

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,5 +1,5 @@
 :root {
-  --gray: rgba(12, 12, 13, 0.15);
+  --gray-separator: rgba(12, 12, 13, 0.15);
 }
 
 body {

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -67,7 +67,7 @@ li {
 }
 
 .item .line.indent {
-  margin-inline-start: 28px !important;
+  margin-inline-start: 28px;
 }
 
 .helper-text {

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -94,3 +94,7 @@ li.indent {
   overflow-wrap: none;
 }
 
+button {
+  padding: 4px 8px;
+}
+

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -28,7 +28,7 @@ section {
 }
 
 h1 {
-  margin: 32px 0 0 0;
+  margin: 32px 0 16px 0;
   padding: 16px 0 0 0;
 
   /* title30 */
@@ -46,7 +46,7 @@ h2{
   /* title20 */
   font-size: 17px;
   font-weight: 600;
-  margin-top: 32px;
+  margin: 32px 0 16px 0;
 }
 
 ul {
@@ -73,10 +73,11 @@ li.indent {
   margin-inline-start: 28px;
 }
 
-.helper-text {
+li.helper-text {
   /* caption20 */
   font-size: 13px;
   color: var(--grey-50);
+  display: inline;
 }
 
 /* when a link is used in a helper text, add margin */

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -20,11 +20,8 @@ body.mobile .mobile-incompatible {
   opacity: 0.4;
 }
 
-#qrQuietZone {
-  position: relative;
-  top: 5px;
-  cursor: pointer;
-  /* -webkit-appearance: none; */
+form {
+  margin: 16px 32px;
 }
 
 h1 {
@@ -74,4 +71,8 @@ h2{
 .helper-text > a {
   margin-left: 4px;
   overflow-wrap: none;
+}
+
+#qrQuietZone {
+  cursor: pointer;
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -31,7 +31,7 @@ section {
 hr {
   border: 0;
   height: 1px;
-  background-color: var(--gray);
+  background-color: var(--gray-separator);
 }
 
 h1 {

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -29,11 +29,12 @@ h1 {
 
   /* title30 */
   font-size: 22px;
-  border-top: 1px solid rgba(12, 12, 13, 0.15);
   font-weight: 300;
+
+  border-top: 1px solid rgba(12, 12, 13, 0.15);
 }
 
-h1:first-child {
+h1.first {
   border-top: none;
 }
 
@@ -51,24 +52,20 @@ ul {
 
 li {
   list-style-type: none;
-  margin-top: 10px;
-  padding: 0px;
-}
 
-.line {
   padding: 2px 0;
-  margin-bottom: 4px;
+  margin: 10px 0 4px 0;
 
   display: flex;
   align-items: center;
 }
 
-.item .line * {
+li * {
   /* https://design.firefox.com/photon/visuals/grid.html#spacing */
   margin: 0 8px 0 0;
 }
 
-.item .line.indent {
+li.indent {
   margin-inline-start: 28px;
 }
 
@@ -84,6 +81,6 @@ li {
   overflow-wrap: none;
 }
 
-#qrQuietZone {
+#qrQuietZone, label {
   cursor: pointer;
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -85,7 +85,3 @@ li.indent {
   margin-left: 4px;
   overflow-wrap: none;
 }
-
-#qrQuietZone, label {
-  cursor: pointer;
-}

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -38,13 +38,27 @@ body.mobile .mobile-incompatible {
 
 h1 {
   margin-bottom: 16px;
+  border-top: 1px solid rgba(12, 12, 13, 0.15);
+  
+  font-weight: 300;
+  font-size: 1.46em;
+}
+
+h1:first-child {
+  border-top: none;
 }
 
 section {
   margin-bottom: 32px;
 }
 
-h2, .line {
+h2{
+  margin-bottom: 4px;
+  font-weight: 600;
+  font-size: 1.14em;
+}
+
+.line {
   margin-bottom: 4px;
 }
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -73,7 +73,7 @@ li.indent {
   margin-inline-start: 28px;
 }
 
-li.helper-text {
+.helper-text {
   /* caption20 */
   font-size: 13px;
   color: var(--grey-50);

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,6 +1,7 @@
 body {
   /* body20 */
   font-size: 15px;
+  padding: 0 8px;
 }
 
 /* on (small) mobile displays */

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -20,61 +20,7 @@ body.mobile .mobile-incompatible {
   opacity: 0.4;
 }
 
-ul {
-  margin: 0px;
-  padding: 0px;
-}
-li {
-  list-style-type: none;
-  margin-top: 10px;
-  padding: 0px;
-}
-/* in a fieldset e.g. we use a condensed version */
-.condensed-list {
-  margin-left: 0px;
-}
-
-fieldset {
-  /* same border style as separators above */
-  border: 1px solid;
-  border-radius: 4px;
-  border-color: var(--grey-30); /* Firefox: --in-content-box-border-color */
-
-  /* a big width, but not too big */
-  display: inline-block;
-  width: auto;
-  min-width: 60vw;
-
-  margin-bottom: 4px;
-}
-
-/* when a setting has a label *before* it, add some margin */
-label + .setting {
-  margin-left: 8px;
-}
-
-.helper-text {
-  display: block;
-  color: var(--grey-50);
-
-  margin-top: 4px;
-}
-
-/* some margin to align with checkbox */
-input[type=checkbox] ~ .helper-text,
-input[type=radio] ~ .helper-text {
-  /* 4px margin-left + 16px size + 3px margin-right + 5px space (#text) */
-  margin-left: 28px;
-}
-
-/* when a link is used in a helper text, add margin */
-.helper-text > a {
-  margin-left: 4px;
-  overflow-wrap: none;
-}
-
 /* special options values */
-
 #popupIconColor {
   display: inline;
 }
@@ -90,8 +36,6 @@ input[type=radio] ~ .helper-text {
   width: 4.5em;
 }
 
-/* TODO: make i icon bigger */
-
 h1 {
   margin-bottom: 16px;
 }
@@ -100,10 +44,26 @@ section {
   margin-bottom: 32px;
 }
 
-h2, .item {
+h2, .line {
   margin-bottom: 4px;
 }
 
-.element {
+.item .line * {
+  display: inline;
   margin-right: 8px;
+}
+
+.item .line.indent {
+  margin-inline-start: 28px !important;
+}
+
+.helper-text {
+  display: block;
+  color: var(--grey-50);
+}
+
+/* when a link is used in a helper text, add margin */
+.helper-text > a {
+  margin-left: 4px;
+  overflow-wrap: none;
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -27,6 +27,12 @@ section {
   margin-bottom: 32px;
 }
 
+hr {
+  border: 0;
+  height: 1px;
+  background-color: rgba(12, 12, 13, 0.15);
+}
+
 h1 {
   margin: 32px 0 16px 0;
   padding: 16px 0 0 0;
@@ -38,7 +44,7 @@ h1 {
   border-top: 1px solid rgba(12, 12, 13, 0.15);
 }
 
-h1.first {
+form section:first-child h1 {
   border-top: none;
 }
 
@@ -85,3 +91,4 @@ li.indent {
   margin-left: 4px;
   overflow-wrap: none;
 }
+

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -74,8 +74,8 @@ li.indent {
 }
 
 .helper-text {
-  /* caption20 */
-  font-size: 13px;
+  /* caption30 */
+  font-size: 15px;
   color: var(--grey-50);
   display: inline;
 }

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -1,7 +1,7 @@
 body {
-  /* the style the other options in the settings pane use */
-  font-size: 1.11em;
   color: #333;
+  font-family: sans-serif;
+  font-size: 14px;
 }
 
 /* on (small) mobile displays */
@@ -20,11 +20,6 @@ body.mobile .mobile-incompatible {
   opacity: 0.4;
 }
 
-/* special options values */
-#popupIconColor {
-  display: inline;
-}
-
 #qrQuietZone {
   position: relative;
   top: 5px;
@@ -32,14 +27,11 @@ body.mobile .mobile-incompatible {
   /* -webkit-appearance: none; */
 }
 
-#qrCodeSizeFixedValue {
-  width: 4.5em;
-}
-
 h1 {
-  margin-bottom: 16px;
+  margin: 0;
+  padding: 16px 0;
+
   border-top: 1px solid rgba(12, 12, 13, 0.15);
-  
   font-weight: 300;
   font-size: 1.46em;
 }
@@ -59,12 +51,15 @@ h2{
 }
 
 .line {
+  padding: 2px 0;
   margin-bottom: 4px;
+
+  display: flex;
+  align-items: center;
 }
 
 .item .line * {
-  display: inline;
-  margin-right: 8px;
+  margin: 0 8px 0 0;
 }
 
 .item .line.indent {
@@ -72,7 +67,6 @@ h2{
 }
 
 .helper-text {
-  display: block;
   color: var(--grey-50);
 }
 

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -91,3 +91,19 @@ input[type=radio] ~ .helper-text {
 }
 
 /* TODO: make i icon bigger */
+
+h1 {
+  margin-bottom: 16px;
+}
+
+section {
+  margin-bottom: 32px;
+}
+
+h2, .item {
+  margin-bottom: 4px;
+}
+
+.element {
+  margin-right: 8px;
+}

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -61,7 +61,7 @@
 		<form>
 			<h1 data-i18n="__MSG_titleGeneral__">General</h1>
 			<ul class="mobile-incompatible">
-				<h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
+				<h2 data-i18n="__MSG_subtitlePopupIconColored__">Colored icon</h2>
 				<li class="item">
 					<div class="line">
 						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
@@ -72,7 +72,7 @@
 
 			<h1 data-i18n="__MSG_titleQrCodeSetting__">QR Code Setting</h1>
 			<ul id="qrCodeType" class="setting save-on-input">
-				<h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
+				<h2 data-i18n="__MSG_subtitleQrCodeType__">QR code type</h2>
 				<li class="item">
 					<div class="line">
 						<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
@@ -94,7 +94,7 @@
 				</li>
 			</ul>
 			<ul id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
-				<h2 data-i18n="__MSG_optionQrCodeSize__">QR code size</h2>
+				<h2 data-i18n="__MSG_subtitleQrCodeSize__">QR code size</h2>
 				<li class="item">
 					<div class="line">
 						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
@@ -123,7 +123,7 @@
 				</li>
 			</ul>
 			<ul>
-				<h2 data-i18n="__MSG_optionMisc__">Miscellaneous Settings</h2>
+				<h2 data-i18n="__MSG_subtitleMisc__">Miscellaneous Settings</h2>
 
 				<li class="item">
 					<div class="line">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -75,34 +75,36 @@
 
 				<h2 data-i18n="__MSG_subtitleQrCodeType__">QR code type</h2>
 
-				<ul id="qrCodeType" data-type="radiogroup">
-					<li>
-						<input class="setting save-on-input" id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg">
-						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
-					</li>
-					<li class="indent">
-						<span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
-					</li>
-				</ul>
+				<div class="setting save-on-input" data-type="radiogroup" id="qrCodeType">
+					<ul>
+						<li>
+							<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg">
+							<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
+						</li>
+						<li class="indent">
+							<span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
+						</li>
+					</ul>
 
-				<ul>
-					<li>
-						<input class="setting save-on-input" id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas">
-						<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
-					</li>
-					<li class="indent">
-						<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
-					</li>
-				</ul>
+					<ul>
+						<li>
+							<input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas">
+							<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
+						</li>
+						<li class="indent">
+							<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
+						</li>
+					</ul>
+				</div>
 
 				<h2 data-i18n="__MSG_subtitleQrCodeSize__">QR code size</h2>
-				<div id="sizeType" data-type="radiogroup" class="setting">
+				<div id="sizeType" data-type="radiogroup" class="setting" data-optiongroup="qrCodeSize">
 					<ul>
 						<li>
 							<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
 							<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
 
-							<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
+							<input data-i18n="__MSG_optionPixelAbbreviation__" class="save-on-change" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
 							<label for="qrCodeSizeFixedValue">px</label>
 						</li>
 					</ul>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -60,7 +60,7 @@
 		</div>
 		<form>
 			<section class="mobile-incompatible">
-				<h1 class="first" data-i18n="__MSG_titleGeneral__">Add-on</h1>
+				<h1 data-i18n="__MSG_titleGeneral__">Add-on</h1>
 				<ul>
 					<li>
 						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
@@ -207,6 +207,7 @@
 			</section>
 
 			<section>
+				<hr />
 				<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
 			</section>
 		</form>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -58,111 +58,156 @@
 				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
 			</div>
 		</div>
+		<h1>Offline QR Code Settings</h1>
 		<form>
-			<ul>
-				<li class="mobile-incompatible">
-					<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
-					<label data-i18n="__MSG_optionPopupIconColored__" for="popupIconColored">Colored icon</label>
-					<span data-i18n="__MSG_optionPopupIconColoredDescr__" class="helper-text">Shows a colored icon instead of the black/white icon in the toolbar.</span>
-				</li>
-				<li>
-					<fieldset id="qrCodeType" data-type="radiogroup" class="setting save-on-input">
-						<legend data-i18n="__MSG_optionQrCodeType__">QR code type</legend>
+			<section class="mobile-incompatible">
+				<h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
+				<div class="item">
+					<div class="line">
+						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
+						<label data-i18n="__MSG_optionPopupIconColoredDescr__" for="popupIconColored" >Shows a colored icon instead of the black/white icon in the toolbar.</label>
+					</div>
+				</div>
+			</section>
+			<section id="qrCodeType" class="setting save-on-input">
+				<h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
+						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
+					</div>
+					<div class="line indent">
+						<span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
+					</div>
+				</div>
 
-						<ul>
-							<li class="condensed-list">
-								<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
-								<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
-								<span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
-							</li>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
+						<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
+					</div>
+					<div class="line indent">
+						<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
+					</div>
+				</div>
+			</section>
+			<section id="sizeType">
+				<h2 data-i18n="__MSG_optionQrCodeSize__">QR code size</h2>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
+						<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
 
-							<li class="condensed-list">
-								<input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
-								<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
-								<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
-							</li>
-						</ul>
-					</fieldset>
-				</li>
-				<li>
-					<fieldset id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
-						<legend data-i18n="__MSG_optionQrCodeSize__">QR code size</legend>
+						<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
+						<label for="qrCodeSizeFixedValue">px</label>
+					</div>
+				</div>
 
-						<ul>
-							<li class="condensed-list">
-								<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
-								<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
+						<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
+					</div>
+					<div class="line indent">
+						<span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
+					</div>
+				</div>
 
-								<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
-								<label for="qrCodeSizeFixedValue">px</label>
-							</li>
-
-							<li class="condensed-list">
-								<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
-								<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
-								<span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
-							</li>
-
-							<li class="condensed-list">
-								<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
-								<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
-							</li>
-						</ul>
-					</fieldset>
-				</li>
-				<li>
-					<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
-					<input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
-					<span>
-						<span id="qrQuietZoneStatus">(1 square)</span>
-					</span>
-					<span class="helper-text">
-						<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
-						<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
-					</span>
-				</li>
-				<li>
-					<label data-i18n="__MSG_optionQrCodeColor__" for="qrColor">QR code color: </label>
-						<input class="setting save-on-change trigger-on-update" type="color" id="qrColor" name="qrColor">
-				</li>
-				<li>
-					<label data-i18n="__MSG_optionQrCodeBackgroundColor__" for="qrBackgroundColor">QR code background color: </label>
-					<input class="setting save-on-change trigger-on-update" type="color" id="qrBackgroundColor" name="qrBackgroundColor">
-				</li>
-				<li>
-					<label data-i18n="__MSG_optionErrorCorrection__" for="qrErrorCorrection">Error correction level: </label>
-					<select id="qrErrorCorrection" class="setting save-on-change" name="qrErrorCorrection" size="0">
-						<option data-i18n="__MSG_optionEcLow__" value="L">Low (7%)</option>
-						<option data-i18n="__MSG_optionEcMedium__" value="M">Medium (15%)</option>
-						<option data-i18n="__MSG_optionEcQuartile__" value="Q">Quartile (25%)</option>
-						<option data-i18n="__MSG_optionEcHigh__" value="H">High (30%)</option>
-					</select>
-					<span class="helper-text">
-						<span data-i18n="__MSG_optionErrorCorrectionDescr__">
-							If a QR code is damaged or some parts are missing, it can often still be scanned.
-							The higher the value the more the machine is able to understand.
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
+						<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
+					</div>
+				</div>
+			</section>
+			<section>
+				<h2>TODO: QR Code Settings</h2>
+				
+				<div class="item">
+					<div class="line">
+						<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
+						<input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
+						<span>
+							<span id="qrQuietZoneStatus">(1 square)</span>
 						</span>
-						<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
-					</span>
-				</li>
-				<li>
-					<input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">
-					<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
-				</li>
-				<li>
-					<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
-					<label data-i18n="__MSG_optionUseMonospaceFont__" for="monospaceFont">Use monospace font</label>
-				</li>
-				<li>
-					<input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
-					<label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
-					<span data-i18n="__MSG_optionDebugModeDescr__" class="helper-text">This is only useful to get more detailed logging output in the console for reporting bugs, etc.</span>
-				</li>
-				<li>
-					<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
-				</li>
-			</ul>
+					</div>
+					
+					<div class="line indent">
+						<span class="helper-text">
+							<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
+							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
+						</span>
+					</div>
+				</div>
+				
+				<div class="item">
+					<div class="line">
+						<label data-i18n="__MSG_optionQrCodeColor__" for="qrColor">QR code color: </label>
+						<input class="setting save-on-change trigger-on-update" type="color" id="qrColor" name="qrColor">
+					</div>
+				</div>
+				
+				<div class="item">
+					<div class="line">
+						<label data-i18n="__MSG_optionQrCodeBackgroundColor__" for="qrBackgroundColor">QR code background color: </label>
+						<input class="setting save-on-change trigger-on-update" type="color" id="qrBackgroundColor" name="qrBackgroundColor">
+					</div>
+				</div>
+				
+				<div class="item">
+					<div class="line">
+						<label data-i18n="__MSG_optionErrorCorrection__" for="qrErrorCorrection">Error correction level: </label>
+						<select id="qrErrorCorrection" class="setting save-on-change" name="qrErrorCorrection" size="0">
+							<option data-i18n="__MSG_optionEcLow__" value="L">Low (7%)</option>
+							<option data-i18n="__MSG_optionEcMedium__" value="M">Medium (15%)</option>
+							<option data-i18n="__MSG_optionEcQuartile__" value="Q">Quartile (25%)</option>
+							<option data-i18n="__MSG_optionEcHigh__" value="H">High (30%)</option>
+						</select>
+					</div>
+					<div class="line indent">
+						<span class="helper-text">
+							<span data-i18n="__MSG_optionErrorCorrectionDescr__">
+								If a QR code is damaged or some parts are missing, it can often still be scanned.
+								The higher the value the more the machine is able to understand.
+							</span>
+							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
+						</span>
+					</div>
+			</section>
+			<section>
+				<h2>TODO: QR Code style</h2>
+				
+				<div class="item">
+					<div class="line">
+						<input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">
+						<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
+					</div>
+				</div>
+				
+				<div class="item">
+					<div class="line">
+						<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
+						<label data-i18n="__MSG_optionUseMonospaceFont__" for="monospaceFont">Use monospace font</label>
+					</div>
+				</div>
+				
+				<div class="item">
+					<div class="line">
+						<input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
+						<label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
+					</div>
+					<div class="line indent">
+						<span data-i18n="__MSG_optionDebugModeDescr__" class="helper-text">This is only useful to get more detailed logging output in the console for reporting bugs, etc.</span>
+					</div>
+				</div>
+			</section>
+			<section>
+				<div class="item">
+					<div class="line">
+						<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
+					</div>
+				</div>
+			</section>
 		</form>
 	</body>
-
 </html>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -59,7 +59,7 @@
 			</div>
 		</div>
 		<form>
-			<h1>TODO: General</h1>
+			<h1 data-i18n="__MSG_titleGeneral__">General</h1>
 			<section class="mobile-incompatible">
 				<h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
 				<div class="item">
@@ -70,7 +70,7 @@
 				</div>
 			</section>
 
-			<h1>TODO: QR Code Setting</h1>
+			<h1 data-i18n="__MSG_titleQrCodeSetting__">QR Code Setting</h1>
 			<section id="qrCodeType" class="setting save-on-input">
 				<h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
 				<div class="item">
@@ -93,7 +93,7 @@
 					</div>
 				</div>
 			</section>
-			<section id="sizeType">
+			<section id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
 				<h2 data-i18n="__MSG_optionQrCodeSize__">QR code size</h2>
 				<div class="item">
 					<div class="line">
@@ -123,7 +123,7 @@
 				</div>
 			</section>
 			<section>
-				<h2>TODO: Miscellaneous Settings</h2>
+				<h2 data-i18n="__MSG_optionMisc__">Miscellaneous Settings</h2>
 
 				<div class="item">
 					<div class="line">
@@ -176,7 +176,7 @@
 						</span>
 					</div>
 			</section>
-			<h1>TODO: Addon behavior</h1>
+			<h1 data-i18n="__MSG_titleAddonBehavior__">Addon behavior</h1>
 			<section>
 				<div class="item">
 					<div class="line">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -75,9 +75,9 @@
 
 				<h2 data-i18n="__MSG_subtitleQrCodeType__">QR code type</h2>
 
-				<ul id="qrCodeType" class="setting save-on-input" data-type="radiogroup">
+				<ul id="qrCodeType" data-type="radiogroup">
 					<li>
-						<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
+						<input class="setting save-on-input" id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
 						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
 					</li>
 					<li class="indent">
@@ -87,7 +87,7 @@
 
 				<ul>
 					<li>
-						<input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
+						<input class="setting save-on-input" id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
 						<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
 					</li>
 					<li class="indent">
@@ -96,9 +96,9 @@
 				</ul>
 
 				<h2 data-i18n="__MSG_subtitleQrCodeSize__">QR code size</h2>
-				<ul id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
+				<ul id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup">
 					<li>
-						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
+						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="setting save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
 
 						<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
@@ -108,7 +108,7 @@
 
 				<ul>
 					<li>
-						<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
+						<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="setting save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
 					</li>
 					<li class="indent">
@@ -118,7 +118,7 @@
 
 				<ul>
 					<li>
-						<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
+						<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="setting save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
 					</li>
 				</ul>
@@ -133,11 +133,9 @@
 						</span>
 					</li>
 
-					<li>
-						<span class="helper-text">
-							<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
-							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
-						</span>
+					<li class="helper-text">
+						<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
+						<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
 					</li>
 				</ul>
 
@@ -165,14 +163,12 @@
 							<option data-i18n="__MSG_optionEcHigh__" value="H">High (30%)</option>
 						</select>
 					</li>
-					<li>
-						<span class="helper-text">
-							<span data-i18n="__MSG_optionErrorCorrectionDescr__">
-								If a QR code is damaged or some parts are missing, it can often still be scanned.
-								The higher the value the more the machine is able to understand.
-							</span>
-							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
+					<li class="helper-text">
+						<span data-i18n="__MSG_optionErrorCorrectionDescr__">
+							If a QR code is damaged or some parts are missing, it can often still be scanned.
+							The higher the value the more the machine is able to understand.
 						</span>
+						<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
 					</li>
 				</ul>
 			</section>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -77,7 +77,7 @@
 
 				<ul id="qrCodeType" data-type="radiogroup">
 					<li>
-						<input class="setting save-on-input" id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
+						<input class="setting save-on-input" id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg">
 						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
 					</li>
 					<li class="indent">
@@ -87,7 +87,7 @@
 
 				<ul>
 					<li>
-						<input class="setting save-on-input" id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
+						<input class="setting save-on-input" id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas">
 						<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
 					</li>
 					<li class="indent">
@@ -96,32 +96,34 @@
 				</ul>
 
 				<h2 data-i18n="__MSG_subtitleQrCodeSize__">QR code size</h2>
-				<ul id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup">
-					<li>
-						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="setting save-on-input">
-						<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
+				<div id="sizeType" data-type="radiogroup" class="setting">
+					<ul>
+						<li>
+							<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
+							<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
 
-						<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
-						<label for="qrCodeSizeFixedValue">px</label>
-					</li>
-				</ul>
+							<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
+							<label for="qrCodeSizeFixedValue">px</label>
+						</li>
+					</ul>
 
-				<ul>
-					<li>
-						<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="setting save-on-input">
-						<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
-					</li>
-					<li class="indent">
-						<span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
-					</li>
-				</ul>
+					<ul>
+						<li>
+							<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
+							<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
+						</li>
+						<li class="indent">
+							<span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
+						</li>
+					</ul>
 
-				<ul>
-					<li>
-						<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="setting save-on-input">
-						<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
-					</li>
-				</ul>
+					<ul>
+						<li>
+							<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
+							<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
+						</li>
+					</ul>
+				</div>
 
 				<h2 data-i18n="__MSG_subtitleMisc__">Miscellaneous Settings</h2>
 				<ul>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,214 +1,214 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="utf-8">
-		<meta name="viewport" content="width=device-width, initial-scale=1.0">
-		<link rel="stylesheet" href="../common/common.css">
-		<link rel="stylesheet" href="options.css">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="../common/common.css">
+    <link rel="stylesheet" href="options.css">
 
-		<script type="module" src="/common/modules/Logger/OverwriteConsoleLog.js" async></script>
-		<script async src="./fastLoad.js" type="module"></script>
+    <script type="module" src="/common/modules/Logger/OverwriteConsoleLog.js" async></script>
+    <script async src="./fastLoad.js" type="module"></script>
 
-		<script defer src="../common/common.js" type="module"></script>
-		<script defer src="./options.js" type="module"></script>
-	</head>
+    <script defer src="../common/common.js" type="module"></script>
+    <script defer src="./options.js" type="module"></script>
+  </head>
 
-	<body>
-		<div class="message-container">
-			<div id="messageTips" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
-				<span class="message-text"></span>
-				<a href="#">
-					<button class="message-action-button micro-button info invisible"></button>
-				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-			</div>
-			<div id="messageInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
-				<span class="message-text">Some settings are managed by your administrator and cannot be changed.</span>
-				<a href="#">
-					<button class="message-action-button micro-button info invisible"></button>
-				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-			</div>
-			<div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide">
-				<span class="message-text">That worked!</span>
-				<a href="#">
-					<button class="message-action-button micro-button success invisible"></button>
-				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-			</div>
-			<div id="messageError" aria-label="error message" data-i18n data-i18n-aria-label="__MSG_ariaMessageError__" class="message-box error invisible fade-hide">
-				<span class="message-text">An error happened.</span>
-				<a href="#">
-					<button class="message-action-button micro-button error invisible"></button>
-				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close-white.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-			</div>
-			<div id="messageWarning" aria-label="warning message" data-i18n data-i18n-aria-label="__MSG_ariaMessageWarning__" class="message-box warning invisible fade-hide">
-				<span class="message-text">There were some difficulties.</span>
-				<a href="#">
-					<button class="message-action-button micro-button warning invisible"></button>
-				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-			</div>
-			<div id="messageContrast" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
-				<span class="message-text"></span>
-				<a href="#">
-					<button class="message-action-button micro-button info invisible"></button>
-				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-			</div>
-		</div>
-		<form>
-			<h1>TODO: General</h1>
-			<section class="mobile-incompatible">
-				<h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
-				<div class="item">
-					<div class="line">
-						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
-						<label data-i18n="__MSG_optionPopupIconColoredDescr__" for="popupIconColored" >Shows a colored icon instead of the black/white icon in the toolbar.</label>
-					</div>
-				</div>
-			</section>
-			
-			<h1>TODO: QR Code Setting</h1>
-			<section id="qrCodeType" class="setting save-on-input">
-				<h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
-				<div class="item">
-					<div class="line">
-						<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
-						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
-					</div>
-					<div class="line indent">
-						<span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
-					</div>
-				</div>
+  <body>
+    <div class="message-container">
+      <div id="messageTips" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+        <span class="message-text"></span>
+        <a href="#">
+          <button class="message-action-button micro-button info invisible"></button>
+        </a>
+        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+      </div>
+      <div id="messageInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+        <span class="message-text">Some settings are managed by your administrator and cannot be changed.</span>
+        <a href="#">
+          <button class="message-action-button micro-button info invisible"></button>
+        </a>
+        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+      </div>
+      <div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide">
+        <span class="message-text">That worked!</span>
+        <a href="#">
+          <button class="message-action-button micro-button success invisible"></button>
+        </a>
+        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+      </div>
+      <div id="messageError" aria-label="error message" data-i18n data-i18n-aria-label="__MSG_ariaMessageError__" class="message-box error invisible fade-hide">
+        <span class="message-text">An error happened.</span>
+        <a href="#">
+          <button class="message-action-button micro-button error invisible"></button>
+        </a>
+        <img class="icon-dismiss invisible" src="/common/img/close-white.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+      </div>
+      <div id="messageWarning" aria-label="warning message" data-i18n data-i18n-aria-label="__MSG_ariaMessageWarning__" class="message-box warning invisible fade-hide">
+        <span class="message-text">There were some difficulties.</span>
+        <a href="#">
+          <button class="message-action-button micro-button warning invisible"></button>
+        </a>
+        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+      </div>
+      <div id="messageContrast" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+        <span class="message-text"></span>
+        <a href="#">
+          <button class="message-action-button micro-button info invisible"></button>
+        </a>
+        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+      </div>
+    </div>
+    <form>
+      <h1>TODO: General</h1>
+      <section class="mobile-incompatible">
+        <h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
+        <div class="item">
+          <div class="line">
+            <input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
+            <label data-i18n="__MSG_optionPopupIconColoredDescr__" for="popupIconColored" >Shows a colored icon instead of the black/white icon in the toolbar.</label>
+          </div>
+        </div>
+      </section>
 
-				<div class="item">
-					<div class="line">
-						<input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
-						<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
-					</div>
-					<div class="line indent">
-						<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
-					</div>
-				</div>
-			</section>
-			<section id="sizeType">
-				<h2 data-i18n="__MSG_optionQrCodeSize__">QR code size</h2>
-				<div class="item">
-					<div class="line">
-						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
-						<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
+      <h1>TODO: QR Code Setting</h1>
+      <section id="qrCodeType" class="setting save-on-input">
+        <h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
+        <div class="item">
+          <div class="line">
+            <input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
+            <label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
+          </div>
+          <div class="line indent">
+            <span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
+          </div>
+        </div>
 
-						<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
-						<label for="qrCodeSizeFixedValue">px</label>
-					</div>
-				</div>
+        <div class="item">
+          <div class="line">
+            <input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
+            <label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
+          </div>
+          <div class="line indent">
+            <span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
+          </div>
+        </div>
+      </section>
+      <section id="sizeType">
+        <h2 data-i18n="__MSG_optionQrCodeSize__">QR code size</h2>
+        <div class="item">
+          <div class="line">
+            <input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
+            <label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
 
-				<div class="item">
-					<div class="line">
-						<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
-						<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
-					</div>
-					<div class="line indent">
-						<span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
-					</div>
-				</div>
+            <input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
+            <label for="qrCodeSizeFixedValue">px</label>
+          </div>
+        </div>
 
-				<div class="item">
-					<div class="line">
-						<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
-						<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
-					</div>
-				</div>
-			</section>
-			<section>
-				<h2>TODO: Miscellaneous Settings</h2>
-				
-				<div class="item">
-					<div class="line">
-						<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
-						<input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
-						<span>
-							<span id="qrQuietZoneStatus">(1 square)</span>
-						</span>
-					</div>
-					
-					<div class="line indent">
-						<span class="helper-text">
-							<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
-							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
-						</span>
-					</div>
-				</div>
-				
-				<div class="item">
-					<div class="line">
-						<label data-i18n="__MSG_optionQrCodeColor__" for="qrColor">QR code color: </label>
-						<input class="setting save-on-change trigger-on-update" type="color" id="qrColor" name="qrColor">
-					</div>
-				</div>
-				
-				<div class="item">
-					<div class="line">
-						<label data-i18n="__MSG_optionQrCodeBackgroundColor__" for="qrBackgroundColor">QR code background color: </label>
-						<input class="setting save-on-change trigger-on-update" type="color" id="qrBackgroundColor" name="qrBackgroundColor">
-					</div>
-				</div>
-				
-				<div class="item">
-					<div class="line">
-						<label data-i18n="__MSG_optionErrorCorrection__" for="qrErrorCorrection">Error correction level: </label>
-						<select id="qrErrorCorrection" class="setting save-on-change" name="qrErrorCorrection" size="0">
-							<option data-i18n="__MSG_optionEcLow__" value="L">Low (7%)</option>
-							<option data-i18n="__MSG_optionEcMedium__" value="M">Medium (15%)</option>
-							<option data-i18n="__MSG_optionEcQuartile__" value="Q">Quartile (25%)</option>
-							<option data-i18n="__MSG_optionEcHigh__" value="H">High (30%)</option>
-						</select>
-					</div>
-					<div class="line indent">
-						<span class="helper-text">
-							<span data-i18n="__MSG_optionErrorCorrectionDescr__">
-								If a QR code is damaged or some parts are missing, it can often still be scanned.
-								The higher the value the more the machine is able to understand.
-							</span>
-							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
-						</span>
-					</div>
-			</section>
-			<h1>TODO: Addon behavior</h1>
-			<section>
-				<div class="item">
-					<div class="line">
-						<input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">
-						<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
-					</div>
-				</div>
-				
-				<div class="item">
-					<div class="line">
-						<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
-						<label data-i18n="__MSG_optionUseMonospaceFont__" for="monospaceFont">Use monospace font</label>
-					</div>
-				</div>
-				
-				<div class="item">
-					<div class="line">
-						<input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
-						<label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
-					</div>
-					<div class="line indent">
-						<span data-i18n="__MSG_optionDebugModeDescr__" class="helper-text">This is only useful to get more detailed logging output in the console for reporting bugs, etc.</span>
-					</div>
-				</div>
-			</section>
-			<section>
-				<div class="item">
-					<div class="line">
-						<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
-					</div>
-				</div>
-			</section>
-		</form>
-	</body>
+        <div class="item">
+          <div class="line">
+            <input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
+            <label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
+          </div>
+          <div class="line indent">
+            <span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="line">
+            <input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
+            <label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
+          </div>
+        </div>
+      </section>
+      <section>
+        <h2>TODO: Miscellaneous Settings</h2>
+
+        <div class="item">
+          <div class="line">
+            <label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
+            <input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
+            <span>
+              <span id="qrQuietZoneStatus">(1 square)</span>
+            </span>
+          </div>
+
+          <div class="line">
+            <span class="helper-text">
+              <span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
+              <a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
+            </span>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="line">
+            <label data-i18n="__MSG_optionQrCodeColor__" for="qrColor">QR code color: </label>
+            <input class="setting save-on-change trigger-on-update" type="color" id="qrColor" name="qrColor">
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="line">
+            <label data-i18n="__MSG_optionQrCodeBackgroundColor__" for="qrBackgroundColor">QR code background color: </label>
+            <input class="setting save-on-change trigger-on-update" type="color" id="qrBackgroundColor" name="qrBackgroundColor">
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="line">
+            <label data-i18n="__MSG_optionErrorCorrection__" for="qrErrorCorrection">Error correction level: </label>
+            <select id="qrErrorCorrection" class="setting save-on-change" name="qrErrorCorrection" size="0">
+              <option data-i18n="__MSG_optionEcLow__" value="L">Low (7%)</option>
+              <option data-i18n="__MSG_optionEcMedium__" value="M">Medium (15%)</option>
+              <option data-i18n="__MSG_optionEcQuartile__" value="Q">Quartile (25%)</option>
+              <option data-i18n="__MSG_optionEcHigh__" value="H">High (30%)</option>
+            </select>
+          </div>
+          <div class="line">
+            <span class="helper-text">
+              <span data-i18n="__MSG_optionErrorCorrectionDescr__">
+                If a QR code is damaged or some parts are missing, it can often still be scanned.
+                The higher the value the more the machine is able to understand.
+              </span>
+              <a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
+            </span>
+          </div>
+      </section>
+      <h1>TODO: Addon behavior</h1>
+      <section>
+        <div class="item">
+          <div class="line">
+            <input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">
+            <label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="line">
+            <input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
+            <label data-i18n="__MSG_optionUseMonospaceFont__" for="monospaceFont">Use monospace font</label>
+          </div>
+        </div>
+
+        <div class="item">
+          <div class="line">
+            <input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
+            <label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
+          </div>
+          <div class="line indent">
+            <span data-i18n="__MSG_optionDebugModeDescr__" class="helper-text">This is only useful to get more detailed logging output in the console for reporting bugs, etc.</span>
+          </div>
+        </div>
+      </section>
+      <section>
+        <div class="item">
+          <div class="line">
+            <button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
+          </div>
+        </div>
+      </section>
+    </form>
+  </body>
 </html>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -60,20 +60,20 @@
 		</div>
 		<form>
 			<h1 data-i18n="__MSG_titleGeneral__">General</h1>
-			<section class="mobile-incompatible">
+			<ul class="mobile-incompatible">
 				<h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
 						<label data-i18n="__MSG_optionPopupIconColoredDescr__" for="popupIconColored" >Shows a colored icon instead of the black/white icon in the toolbar.</label>
 					</div>
-				</div>
-			</section>
+				</li>
+			</ul>
 
 			<h1 data-i18n="__MSG_titleQrCodeSetting__">QR Code Setting</h1>
-			<section id="qrCodeType" class="setting save-on-input">
+			<ul id="qrCodeType" class="setting save-on-input">
 				<h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
 						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
@@ -81,9 +81,9 @@
 					<div class="line indent">
 						<span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
 					</div>
-				</div>
+				</li>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
 						<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
@@ -91,11 +91,11 @@
 					<div class="line indent">
 						<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
 					</div>
-				</div>
-			</section>
-			<section id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
+				</li>
+			</ul>
+			<ul id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
 				<h2 data-i18n="__MSG_optionQrCodeSize__">QR code size</h2>
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
@@ -103,9 +103,9 @@
 						<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
 						<label for="qrCodeSizeFixedValue">px</label>
 					</div>
-				</div>
+				</li>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
@@ -113,19 +113,19 @@
 					<div class="line indent">
 						<span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
 					</div>
-				</div>
+				</li>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
 					</div>
-				</div>
-			</section>
-			<section>
+				</li>
+			</ul>
+			<ul>
 				<h2 data-i18n="__MSG_optionMisc__">Miscellaneous Settings</h2>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
 						<input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
@@ -140,23 +140,23 @@
 							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
 						</span>
 					</div>
-				</div>
+				</li>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<label data-i18n="__MSG_optionQrCodeColor__" for="qrColor">QR code color: </label>
 						<input class="setting save-on-change trigger-on-update" type="color" id="qrColor" name="qrColor">
 					</div>
-				</div>
+				</li>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<label data-i18n="__MSG_optionQrCodeBackgroundColor__" for="qrBackgroundColor">QR code background color: </label>
 						<input class="setting save-on-change trigger-on-update" type="color" id="qrBackgroundColor" name="qrBackgroundColor">
 					</div>
-				</div>
+				</li>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<label data-i18n="__MSG_optionErrorCorrection__" for="qrErrorCorrection">Error correction level: </label>
 						<select id="qrErrorCorrection" class="setting save-on-change" name="qrErrorCorrection" size="0">
@@ -175,24 +175,25 @@
 							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
 						</span>
 					</div>
-			</section>
+				</li>
+			</ul>
 			<h1 data-i18n="__MSG_titleAddonBehavior__">Addon behavior</h1>
-			<section>
-				<div class="item">
+			<ul>
+				<li class="item">
 					<div class="line">
 						<input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">
 						<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
 					</div>
-				</div>
+				</li>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
 						<label data-i18n="__MSG_optionUseMonospaceFont__" for="monospaceFont">Use monospace font</label>
 					</div>
-				</div>
+				</li>
 
-				<div class="item">
+				<li class="item">
 					<div class="line">
 						<input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
 						<label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
@@ -200,15 +201,15 @@
 					<div class="line indent">
 						<span data-i18n="__MSG_optionDebugModeDescr__" class="helper-text">This is only useful to get more detailed logging output in the console for reporting bugs, etc.</span>
 					</div>
-				</div>
-			</section>
-			<section>
-				<div class="item">
+				</li>
+			</ul>
+			<ul>
+				<li class="item">
 					<div class="line">
 						<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
 					</div>
-				</div>
-			</section>
+				</li>
+			</ul>
 		</form>
 	</body>
 </html>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -207,7 +207,7 @@
 			</section>
 
 			<section>
-				<hr />
+				<br /><br />
 				<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
 			</section>
 		</form>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -58,8 +58,8 @@
 				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
 			</div>
 		</div>
-		<h1>Offline QR Code Settings</h1>
 		<form>
+			<h1>TODO: General</h1>
 			<section class="mobile-incompatible">
 				<h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
 				<div class="item">
@@ -69,6 +69,8 @@
 					</div>
 				</div>
 			</section>
+			
+			<h1>TODO: QR Code Setting</h1>
 			<section id="qrCodeType" class="setting save-on-input">
 				<h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
 				<div class="item">
@@ -121,7 +123,7 @@
 				</div>
 			</section>
 			<section>
-				<h2>TODO: QR Code Settings</h2>
+				<h2>TODO: Miscellaneous Settings</h2>
 				
 				<div class="item">
 					<div class="line">
@@ -174,9 +176,8 @@
 						</span>
 					</div>
 			</section>
+			<h1>TODO: Addon behavior</h1>
 			<section>
-				<h2>TODO: QR Code style</h2>
-				
 				<div class="item">
 					<div class="line">
 						<input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -1,214 +1,214 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="../common/common.css">
-    <link rel="stylesheet" href="options.css">
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0">
+		<link rel="stylesheet" href="../common/common.css">
+		<link rel="stylesheet" href="options.css">
 
-    <script type="module" src="/common/modules/Logger/OverwriteConsoleLog.js" async></script>
-    <script async src="./fastLoad.js" type="module"></script>
+		<script type="module" src="/common/modules/Logger/OverwriteConsoleLog.js" async></script>
+		<script async src="./fastLoad.js" type="module"></script>
 
-    <script defer src="../common/common.js" type="module"></script>
-    <script defer src="./options.js" type="module"></script>
-  </head>
+		<script defer src="../common/common.js" type="module"></script>
+		<script defer src="./options.js" type="module"></script>
+	</head>
 
-  <body>
-    <div class="message-container">
-      <div id="messageTips" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
-        <span class="message-text"></span>
-        <a href="#">
-          <button class="message-action-button micro-button info invisible"></button>
-        </a>
-        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-      </div>
-      <div id="messageInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
-        <span class="message-text">Some settings are managed by your administrator and cannot be changed.</span>
-        <a href="#">
-          <button class="message-action-button micro-button info invisible"></button>
-        </a>
-        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-      </div>
-      <div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide">
-        <span class="message-text">That worked!</span>
-        <a href="#">
-          <button class="message-action-button micro-button success invisible"></button>
-        </a>
-        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-      </div>
-      <div id="messageError" aria-label="error message" data-i18n data-i18n-aria-label="__MSG_ariaMessageError__" class="message-box error invisible fade-hide">
-        <span class="message-text">An error happened.</span>
-        <a href="#">
-          <button class="message-action-button micro-button error invisible"></button>
-        </a>
-        <img class="icon-dismiss invisible" src="/common/img/close-white.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-      </div>
-      <div id="messageWarning" aria-label="warning message" data-i18n data-i18n-aria-label="__MSG_ariaMessageWarning__" class="message-box warning invisible fade-hide">
-        <span class="message-text">There were some difficulties.</span>
-        <a href="#">
-          <button class="message-action-button micro-button warning invisible"></button>
-        </a>
-        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-      </div>
-      <div id="messageContrast" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
-        <span class="message-text"></span>
-        <a href="#">
-          <button class="message-action-button micro-button info invisible"></button>
-        </a>
-        <img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-      </div>
-    </div>
-    <form>
-      <h1>TODO: General</h1>
-      <section class="mobile-incompatible">
-        <h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
-        <div class="item">
-          <div class="line">
-            <input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
-            <label data-i18n="__MSG_optionPopupIconColoredDescr__" for="popupIconColored" >Shows a colored icon instead of the black/white icon in the toolbar.</label>
-          </div>
-        </div>
-      </section>
+	<body>
+		<div class="message-container">
+			<div id="messageTips" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+				<span class="message-text"></span>
+				<a href="#">
+					<button class="message-action-button micro-button info invisible"></button>
+				</a>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+			</div>
+			<div id="messageInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+				<span class="message-text">Some settings are managed by your administrator and cannot be changed.</span>
+				<a href="#">
+					<button class="message-action-button micro-button info invisible"></button>
+				</a>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+			</div>
+			<div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide">
+				<span class="message-text">That worked!</span>
+				<a href="#">
+					<button class="message-action-button micro-button success invisible"></button>
+				</a>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+			</div>
+			<div id="messageError" aria-label="error message" data-i18n data-i18n-aria-label="__MSG_ariaMessageError__" class="message-box error invisible fade-hide">
+				<span class="message-text">An error happened.</span>
+				<a href="#">
+					<button class="message-action-button micro-button error invisible"></button>
+				</a>
+				<img class="icon-dismiss invisible" src="/common/img/close-white.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+			</div>
+			<div id="messageWarning" aria-label="warning message" data-i18n data-i18n-aria-label="__MSG_ariaMessageWarning__" class="message-box warning invisible fade-hide">
+				<span class="message-text">There were some difficulties.</span>
+				<a href="#">
+					<button class="message-action-button micro-button warning invisible"></button>
+				</a>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+			</div>
+			<div id="messageContrast" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+				<span class="message-text"></span>
+				<a href="#">
+					<button class="message-action-button micro-button info invisible"></button>
+				</a>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+			</div>
+		</div>
+		<form>
+			<h1>TODO: General</h1>
+			<section class="mobile-incompatible">
+				<h2 data-i18n="__MSG_optionPopupIconColored__">Colored icon</h2>
+				<div class="item">
+					<div class="line">
+						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
+						<label data-i18n="__MSG_optionPopupIconColoredDescr__" for="popupIconColored" >Shows a colored icon instead of the black/white icon in the toolbar.</label>
+					</div>
+				</div>
+			</section>
 
-      <h1>TODO: QR Code Setting</h1>
-      <section id="qrCodeType" class="setting save-on-input">
-        <h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
-        <div class="item">
-          <div class="line">
-            <input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
-            <label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
-          </div>
-          <div class="line indent">
-            <span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
-          </div>
-        </div>
+			<h1>TODO: QR Code Setting</h1>
+			<section id="qrCodeType" class="setting save-on-input">
+				<h2 data-i18n="__MSG_optionQrCodeType__">QR code type</h2>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
+						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
+					</div>
+					<div class="line indent">
+						<span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
+					</div>
+				</div>
 
-        <div class="item">
-          <div class="line">
-            <input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
-            <label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
-          </div>
-          <div class="line indent">
-            <span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
-          </div>
-        </div>
-      </section>
-      <section id="sizeType">
-        <h2 data-i18n="__MSG_optionQrCodeSize__">QR code size</h2>
-        <div class="item">
-          <div class="line">
-            <input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
-            <label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
+						<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
+					</div>
+					<div class="line indent">
+						<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
+					</div>
+				</div>
+			</section>
+			<section id="sizeType">
+				<h2 data-i18n="__MSG_optionQrCodeSize__">QR code size</h2>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
+						<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
 
-            <input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
-            <label for="qrCodeSizeFixedValue">px</label>
-          </div>
-        </div>
+						<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
+						<label for="qrCodeSizeFixedValue">px</label>
+					</div>
+				</div>
 
-        <div class="item">
-          <div class="line">
-            <input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
-            <label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
-          </div>
-          <div class="line indent">
-            <span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
-          </div>
-        </div>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
+						<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
+					</div>
+					<div class="line indent">
+						<span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
+					</div>
+				</div>
 
-        <div class="item">
-          <div class="line">
-            <input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
-            <label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
-          </div>
-        </div>
-      </section>
-      <section>
-        <h2>TODO: Miscellaneous Settings</h2>
+				<div class="item">
+					<div class="line">
+						<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
+						<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
+					</div>
+				</div>
+			</section>
+			<section>
+				<h2>TODO: Miscellaneous Settings</h2>
 
-        <div class="item">
-          <div class="line">
-            <label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
-            <input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
-            <span>
-              <span id="qrQuietZoneStatus">(1 square)</span>
-            </span>
-          </div>
+				<div class="item">
+					<div class="line">
+						<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
+						<input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
+						<span>
+							<span id="qrQuietZoneStatus">(1 square)</span>
+						</span>
+					</div>
 
-          <div class="line">
-            <span class="helper-text">
-              <span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
-              <a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
-            </span>
-          </div>
-        </div>
+					<div class="line">
+						<span class="helper-text">
+							<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
+							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
+						</span>
+					</div>
+				</div>
 
-        <div class="item">
-          <div class="line">
-            <label data-i18n="__MSG_optionQrCodeColor__" for="qrColor">QR code color: </label>
-            <input class="setting save-on-change trigger-on-update" type="color" id="qrColor" name="qrColor">
-          </div>
-        </div>
+				<div class="item">
+					<div class="line">
+						<label data-i18n="__MSG_optionQrCodeColor__" for="qrColor">QR code color: </label>
+						<input class="setting save-on-change trigger-on-update" type="color" id="qrColor" name="qrColor">
+					</div>
+				</div>
 
-        <div class="item">
-          <div class="line">
-            <label data-i18n="__MSG_optionQrCodeBackgroundColor__" for="qrBackgroundColor">QR code background color: </label>
-            <input class="setting save-on-change trigger-on-update" type="color" id="qrBackgroundColor" name="qrBackgroundColor">
-          </div>
-        </div>
+				<div class="item">
+					<div class="line">
+						<label data-i18n="__MSG_optionQrCodeBackgroundColor__" for="qrBackgroundColor">QR code background color: </label>
+						<input class="setting save-on-change trigger-on-update" type="color" id="qrBackgroundColor" name="qrBackgroundColor">
+					</div>
+				</div>
 
-        <div class="item">
-          <div class="line">
-            <label data-i18n="__MSG_optionErrorCorrection__" for="qrErrorCorrection">Error correction level: </label>
-            <select id="qrErrorCorrection" class="setting save-on-change" name="qrErrorCorrection" size="0">
-              <option data-i18n="__MSG_optionEcLow__" value="L">Low (7%)</option>
-              <option data-i18n="__MSG_optionEcMedium__" value="M">Medium (15%)</option>
-              <option data-i18n="__MSG_optionEcQuartile__" value="Q">Quartile (25%)</option>
-              <option data-i18n="__MSG_optionEcHigh__" value="H">High (30%)</option>
-            </select>
-          </div>
-          <div class="line">
-            <span class="helper-text">
-              <span data-i18n="__MSG_optionErrorCorrectionDescr__">
-                If a QR code is damaged or some parts are missing, it can often still be scanned.
-                The higher the value the more the machine is able to understand.
-              </span>
-              <a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
-            </span>
-          </div>
-      </section>
-      <h1>TODO: Addon behavior</h1>
-      <section>
-        <div class="item">
-          <div class="line">
-            <input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">
-            <label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
-          </div>
-        </div>
+				<div class="item">
+					<div class="line">
+						<label data-i18n="__MSG_optionErrorCorrection__" for="qrErrorCorrection">Error correction level: </label>
+						<select id="qrErrorCorrection" class="setting save-on-change" name="qrErrorCorrection" size="0">
+							<option data-i18n="__MSG_optionEcLow__" value="L">Low (7%)</option>
+							<option data-i18n="__MSG_optionEcMedium__" value="M">Medium (15%)</option>
+							<option data-i18n="__MSG_optionEcQuartile__" value="Q">Quartile (25%)</option>
+							<option data-i18n="__MSG_optionEcHigh__" value="H">High (30%)</option>
+						</select>
+					</div>
+					<div class="line">
+						<span class="helper-text">
+							<span data-i18n="__MSG_optionErrorCorrectionDescr__">
+								If a QR code is damaged or some parts are missing, it can often still be scanned.
+								The higher the value the more the machine is able to understand.
+							</span>
+							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
+						</span>
+					</div>
+			</section>
+			<h1>TODO: Addon behavior</h1>
+			<section>
+				<div class="item">
+					<div class="line">
+						<input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">
+						<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
+					</div>
+				</div>
 
-        <div class="item">
-          <div class="line">
-            <input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
-            <label data-i18n="__MSG_optionUseMonospaceFont__" for="monospaceFont">Use monospace font</label>
-          </div>
-        </div>
+				<div class="item">
+					<div class="line">
+						<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
+						<label data-i18n="__MSG_optionUseMonospaceFont__" for="monospaceFont">Use monospace font</label>
+					</div>
+				</div>
 
-        <div class="item">
-          <div class="line">
-            <input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
-            <label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
-          </div>
-          <div class="line indent">
-            <span data-i18n="__MSG_optionDebugModeDescr__" class="helper-text">This is only useful to get more detailed logging output in the console for reporting bugs, etc.</span>
-          </div>
-        </div>
-      </section>
-      <section>
-        <div class="item">
-          <div class="line">
-            <button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
-          </div>
-        </div>
-      </section>
-    </form>
-  </body>
+				<div class="item">
+					<div class="line">
+						<input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
+						<label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
+					</div>
+					<div class="line indent">
+						<span data-i18n="__MSG_optionDebugModeDescr__" class="helper-text">This is only useful to get more detailed logging output in the console for reporting bugs, etc.</span>
+					</div>
+				</div>
+			</section>
+			<section>
+				<div class="item">
+					<div class="line">
+						<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
+					</div>
+				</div>
+			</section>
+		</form>
+	</body>
 </html>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -104,7 +104,7 @@
 							<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
 							<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
 
-							<input data-i18n="__MSG_optionPixelAbbreviation__" class="save-on-change" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
+							<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
 							<label for="qrCodeSizeFixedValue">px</label>
 						</li>
 					</ul>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -60,8 +60,7 @@
 		</div>
 		<form>
 			<section class="mobile-incompatible">
-				<h1 class="first" data-i18n="__MSG_titleGeneral__">General</h1>
-				<h2 data-i18n="__MSG_subtitlePopupIconColored__">Colored icon</h2>
+				<h1 class="first" data-i18n="__MSG_titleGeneral__">Add On</h1>
 				<ul>
 					<li>
 						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -59,105 +59,107 @@
 			</div>
 		</div>
 		<form>
-			<h1 data-i18n="__MSG_titleGeneral__">General</h1>
-			<ul class="mobile-incompatible">
+			<h1 class="first" data-i18n="__MSG_titleGeneral__">General</h1>
+			<section class="mobile-incompatible">
 				<h2 data-i18n="__MSG_subtitlePopupIconColored__">Colored icon</h2>
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
 						<label data-i18n="__MSG_optionPopupIconColoredDescr__" for="popupIconColored" >Shows a colored icon instead of the black/white icon in the toolbar.</label>
-					</div>
-				</li>
-			</ul>
+					</li>
+				</ul>
+			</section>
 
-			<h1 data-i18n="__MSG_titleQrCodeSetting__">QR Code Setting</h1>
-			<ul id="qrCodeType" class="setting save-on-input">
+			<section>
+				<h1 data-i18n="__MSG_titleQrCodeSetting__">QR Code Setting</h1>
+
 				<h2 data-i18n="__MSG_subtitleQrCodeType__">QR code type</h2>
-				<li class="item">
-					<div class="line">
+
+				<ul id="qrCodeType" class="setting save-on-input" data-optiongroup="qrCodeSize" data-type="radiogroup">
+					<li>
 						<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
 						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>
-					</div>
-					<div class="line indent">
+					</li>
+					<li class="indent">
 						<span data-i18n="__MSG_optionQrCodeTypeSvgHelper__" class="helper-text">Uses a modern generation method with vector graphics that enable smoother resizing.</span>
-					</div>
-				</li>
+					</li>
+				</ul>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<input id="qrCodeTypeCanvas" type="radio" name="qrCodeType" value="canvas" class="">
 						<label data-i18n="__MSG_optionQrCodeTypeCanvas__" for="qrCodeTypeCanvas">Canvas image</label>
-					</div>
-					<div class="line indent">
+					</li>
+					<li class="indent">
 						<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
-					</div>
-				</li>
-			</ul>
-			<ul id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
+					</li>
+				</ul>
+			</section>
+			<section id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
 				<h2 data-i18n="__MSG_subtitleQrCodeSize__">QR code size</h2>
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
 
 						<input data-i18n="__MSG_optionPixelAbbreviation__" class="setting save-on-change" data-optiongroup="qrCodeSize" type="number" id="qrCodeSizeFixedValue" min="160" step="5" size="5" name="size">
 						<label for="qrCodeSizeFixedValue">px</label>
-					</div>
-				</li>
+					</li>
+				</ul>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<input id="qrCodeSizeAuto" type="radio" name="sizeType" value="auto" class="save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeAuto__" for="qrCodeSizeAuto">Automatically adjust size</label>
-					</div>
-					<div class="line indent">
+					</li>
+					<li class="indent">
 						<span data-i18n="__MSG_optionQrCodeSizeAutoHelper__" class="helper-text">Mostly useful on mobile devices, where the QR code opens in a new tab.</span>
-					</div>
-				</li>
+					</li>
+				</ul>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<input id="qrCodeSizeRemember" type="radio" name="sizeType" value="remember" class="save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
-					</div>
-				</li>
-			</ul>
-			<ul>
+					</li>
+				</ul>
+			</section>
+			<section>
 				<h2 data-i18n="__MSG_subtitleMisc__">Miscellaneous Settings</h2>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
 						<input class="setting save-on-input" type="range" value="1" min="0" max="5" step="1" id="qrQuietZone" name="qrQuietZone">
 						<span>
 							<span id="qrQuietZoneStatus">(1 square)</span>
 						</span>
-					</div>
+					</li>
 
-					<div class="line">
+					<li>
 						<span class="helper-text">
 							<span data-i18n="__MSG_optionQrQuietZoneDescr__">The number of border modules around the QR code colored in the background color.</span>
 							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionQrQuietZoneDescrLink__" href="https://github.com/rugk/offline-qr-code/wiki/FAQ#what-is-a-quiet-zone">Learn more</a>
 						</span>
-					</div>
-				</li>
+					</li>
+				</ul>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<label data-i18n="__MSG_optionQrCodeColor__" for="qrColor">QR code color: </label>
 						<input class="setting save-on-change trigger-on-update" type="color" id="qrColor" name="qrColor">
-					</div>
-				</li>
+					</li>
+				</ul>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<label data-i18n="__MSG_optionQrCodeBackgroundColor__" for="qrBackgroundColor">QR code background color: </label>
 						<input class="setting save-on-change trigger-on-update" type="color" id="qrBackgroundColor" name="qrBackgroundColor">
-					</div>
-				</li>
+					</li>
+				</ul>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<label data-i18n="__MSG_optionErrorCorrection__" for="qrErrorCorrection">Error correction level: </label>
 						<select id="qrErrorCorrection" class="setting save-on-change" name="qrErrorCorrection" size="0">
 							<option data-i18n="__MSG_optionEcLow__" value="L">Low (7%)</option>
@@ -165,8 +167,8 @@
 							<option data-i18n="__MSG_optionEcQuartile__" value="Q">Quartile (25%)</option>
 							<option data-i18n="__MSG_optionEcHigh__" value="H">High (30%)</option>
 						</select>
-					</div>
-					<div class="line">
+					</li>
+					<li>
 						<span class="helper-text">
 							<span data-i18n="__MSG_optionErrorCorrectionDescr__">
 								If a QR code is damaged or some parts are missing, it can often still be scanned.
@@ -174,42 +176,38 @@
 							</span>
 							<a data-i18n="__MSG_optionLearnMore__" data-i18n-href="__MSG_optionErrorCorrectionDescrLink__" href="https://en.wikipedia.org/wiki/QR_code#Error_correction">Learn more</a>
 						</span>
-					</div>
-				</li>
-			</ul>
-			<h1 data-i18n="__MSG_titleAddonBehavior__">Addon behavior</h1>
-			<ul>
-				<li class="item">
-					<div class="line">
+					</li>
+				</ul>
+			</section>
+			<section>
+				<h1 data-i18n="__MSG_titleAddonBehavior__">Addon behavior</h1>
+				<ul>
+					<li>
 						<input class="setting save-on-change" type="checkbox" id="autoGetSelectedText" name="autoGetSelectedText">
 						<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
-					</div>
-				</li>
+					</li>
+				</ul>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
 						<label data-i18n="__MSG_optionUseMonospaceFont__" for="monospaceFont">Use monospace font</label>
-					</div>
-				</li>
+					</li>
+				</ul>
 
-				<li class="item">
-					<div class="line">
+				<ul>
+					<li>
 						<input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
 						<label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
-					</div>
-					<div class="line indent">
+					</li>
+					<li class="indent">
 						<span data-i18n="__MSG_optionDebugModeDescr__" class="helper-text">This is only useful to get more detailed logging output in the console for reporting bugs, etc.</span>
-					</div>
-				</li>
-			</ul>
-			<ul>
-				<li class="item">
-					<div class="line">
-						<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
-					</div>
-				</li>
-			</ul>
+					</li>
+				</ul>
+			</section>
+			<section>
+				<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
+			</section>
 		</form>
 	</body>
 </html>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -60,7 +60,7 @@
 		</div>
 		<form>
 			<section class="mobile-incompatible">
-				<h1 class="first" data-i18n="__MSG_titleGeneral__">Add On</h1>
+				<h1 class="first" data-i18n="__MSG_titleGeneral__">Add-on</h1>
 				<ul>
 					<li>
 						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
@@ -73,7 +73,7 @@
 			</section>
 
 			<section>
-				<h1 data-i18n="__MSG_titleQrCodeSetting__">QR Code Setting</h1>
+				<h1 data-i18n="__MSG_titleQrCodeSetting__">QR code</h1>
 
 				<h2 data-i18n="__MSG_subtitleQrCodeType__">QR code type</h2>
 
@@ -129,7 +129,7 @@
 					</ul>
 				</div>
 
-				<h2 data-i18n="__MSG_subtitleMisc__">Miscellaneous Settings</h2>
+				<h2 data-i18n="__MSG_subtitleMisc__">Miscellaneous settings</h2>
 				<ul>
 					<li>
 						<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -64,7 +64,10 @@
 				<ul>
 					<li>
 						<input class="setting save-on-change" type="checkbox" id="popupIconColored" name="popupIconColored">
-						<label data-i18n="__MSG_optionPopupIconColoredDescr__" for="popupIconColored" >Shows a colored icon instead of the black/white icon in the toolbar.</label>
+						<label data-i18n="__MSG_optionPopupIconColored__" for="popupIconColored">Colored Icon</label>
+					</li>
+					<li class="indent">
+						<span class="helper-text" data-i18n="__MSG_optionPopupIconColoredDescr__">Shows a colored icon instead of the black/white icon in the toolbar.</span>
 					</li>
 				</ul>
 			</section>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -59,8 +59,8 @@
 			</div>
 		</div>
 		<form>
-			<h1 class="first" data-i18n="__MSG_titleGeneral__">General</h1>
 			<section class="mobile-incompatible">
+				<h1 class="first" data-i18n="__MSG_titleGeneral__">General</h1>
 				<h2 data-i18n="__MSG_subtitlePopupIconColored__">Colored icon</h2>
 				<ul>
 					<li>
@@ -94,10 +94,9 @@
 						<span data-i18n="__MSG_optionQrCodeTypeCanvasHelper__" class="helper-text">A legacy generation method generating the QR code as an image ("canvas").</span>
 					</li>
 				</ul>
-			</section>
-			<section id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
+
 				<h2 data-i18n="__MSG_subtitleQrCodeSize__">QR code size</h2>
-				<ul>
+				<ul id="sizeType" data-optiongroup="qrCodeSize" data-type="radiogroup" class="setting">
 					<li>
 						<input id="qrCodeSizeFixed" type="radio" name="sizeType" value="fixed" class="save-on-input">
 						<label data-i18n="__MSG_optionQrCodeSizeFixed__" for="qrCodeSizeFixed">Fixed size: </label>
@@ -123,10 +122,8 @@
 						<label data-i18n="__MSG_optionQrCodeSizeRemember__" for="qrCodeSizeRemember">Remember last size</label>
 					</li>
 				</ul>
-			</section>
-			<section>
-				<h2 data-i18n="__MSG_subtitleMisc__">Miscellaneous Settings</h2>
 
+				<h2 data-i18n="__MSG_subtitleMisc__">Miscellaneous Settings</h2>
 				<ul>
 					<li>
 						<label data-i18n="__MSG_optionQrQuietZone__" for="qrQuietZone">QR quiet zone: </label>
@@ -179,6 +176,7 @@
 					</li>
 				</ul>
 			</section>
+
 			<section>
 				<h1 data-i18n="__MSG_titleAddonBehavior__">Addon behavior</h1>
 				<ul>
@@ -205,6 +203,7 @@
 					</li>
 				</ul>
 			</section>
+
 			<section>
 				<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
 			</section>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -75,7 +75,7 @@
 
 				<h2 data-i18n="__MSG_subtitleQrCodeType__">QR code type</h2>
 
-				<ul id="qrCodeType" class="setting save-on-input" data-optiongroup="qrCodeSize" data-type="radiogroup">
+				<ul id="qrCodeType" class="setting save-on-input" data-type="radiogroup">
 					<li>
 						<input id="qrCodeTypeSvg" type="radio" name="qrCodeType" value="svg" class="">
 						<label data-i18n="__MSG_optionQrCodeTypeSvg__" for="qrCodeTypeSvg">SVG</label>


### PR DESCRIPTION
closes #43 

```
Currently the options page is not inline with the style guide used by 
firefox's setting pages (e.g. `about:preferences`).

Let's update the option page to use similar styles and at the same 
time, add some grouping to the options to enhance the page.
```