### PR TITLE
close #186 (Automatic) dark mode

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,6 +3,7 @@
 - Alexander Knipping ([@obitech](https://github.com/obitech))
 - Amauri Bizerra ([@AmauriAires](https://github.com/AmauriAires))
 - [@anirudh-modi](https://github.com/anirudh-modi)
+- David Floyd [@davidfloyd91](https://github.com/davidfloyd91)
 - [@ENT8R](https://github.com/ENT8R)
 - Flo Becker ([@beckerei](https://github.com/beckerei))
 - Josh Cooper ([@JoshCooperr](https://github.com/JoshCooperr))
@@ -13,7 +14,6 @@
 - [@redagavin](https://github.com/redagavin)
 - [@Thammarith](https://github.com/Thammarith)
 - [@xlomonosvx](https://github.com/xlomonosvx)
-- David Floyd [@davidfloyd91](https://github.com/davidfloyd91)
 
 ## Translators
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@
 - [@redagavin](https://github.com/redagavin)
 - [@Thammarith](https://github.com/Thammarith)
 - [@xlomonosvx](https://github.com/xlomonosvx)
+- David Floyd [@davidfloyd91](https://github.com/davidfloyd91)
 
 ## Translators
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,6 +1,7 @@
 # Contributors
 
 - Alexander Knipping ([@obitech](https://github.com/obitech))
+- Andrew Jones ([@cornu-ammonis](https://github.com/cornu-ammonis))
 - Amauri Bizerra ([@AmauriAires](https://github.com/AmauriAires))
 - [@anirudh-modi](https://github.com/anirudh-modi)
 - David Floyd [@davidfloyd91](https://github.com/davidfloyd91)

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -15,7 +15,7 @@
 // checks for OS dark theme and returns the appropriate background color
  const setQrBackgroundColor = () => {
      if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        return "#4a4a4f"; // Photon Grey 60
+        return "#d7d7db"; // Photon Grey 30
      } else {
         return "ffffff";
      }

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -11,12 +11,22 @@
  * @const
  * @type {Object}
  */
+
+// checks for OS dark theme and returns the appropriate background color
+ const setQrBackgroundColor = () => {
+     if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return "#4a4a4f"; // Photon Grey 60
+     } else {
+        return "ffffff";
+     }
+ };
+
 const defaultSettings = Object.freeze({
     debugMode: false,
     popupIconColored: false,
     qrCodeType: "svg",
     qrColor: "#0c0c0d",
-    qrBackgroundColor: "#ffffff",
+    qrBackgroundColor: setQrBackgroundColor(),
     qrErrorCorrection: "Q",
     autoGetSelectedText: false,
     monospaceFont: false,

--- a/src/common/variables.css
+++ b/src/common/variables.css
@@ -36,6 +36,7 @@
   --grey-20: #ededf0;
   --grey-30: #d7d7db;
   --grey-50: #737373;
+  --grey-60: #4a4a4f;
   --grey-90: #0c0c0d;
   --grey-90-a10: rgba(12, 12, 13, 0.1);
   --grey-90-a20: rgba(12, 12, 13, 0.2);

--- a/src/popup/modules/UserInterface.js
+++ b/src/popup/modules/UserInterface.js
@@ -536,16 +536,11 @@ export function init() {
             // checks for OS dark theme and sets appropriate background colors
             if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
                 // sets dark theme background and text colors in text field
-                qrCodeText.style.backgroundColor = "#4a4a4f"; // Photon Grey 60
+                qrCodeText.style.backgroundColor = "#4a4a4f"; // Photon Grey 60 -- FF dark theme popup color
                 qrCodeText.style.color = "#ffffff";
-
-                if (qrBackgroundColor === "#4a4a4f") {
-                    // sets qrCode inner background color if user hasn't selected their own color
-                    qrCode.style.backgroundColor = "rgba(249,249,250,0.8)"; // Photon Grey 90 a80
-                } else {
-                    // otherwise matches qrCode inner background color to user's selected background color
-                    qrCode.style.backgroundColor = qrBackgroundColor;
-                }
+            } else {
+                // otherwise matches qrCode inner background color to user's selected background color
+                qrCode.style.backgroundColor = qrBackgroundColor;
             }
         }
     });

--- a/src/popup/modules/UserInterface.js
+++ b/src/popup/modules/UserInterface.js
@@ -532,6 +532,21 @@ export function init() {
     const applyingQrColor = AddonSettings.get("qrBackgroundColor").then((qrBackgroundColor) => {
         if (qrBackgroundColor) {
             document.body.style.backgroundColor = qrBackgroundColor;
+
+            // checks for OS dark theme and sets appropriate background colors
+            if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+                // sets dark theme background and text colors in text field
+                qrCodeText.style.backgroundColor = "#4a4a4f"; // Photon Grey 60
+                qrCodeText.style.color = "#ffffff";
+
+                if (qrBackgroundColor === "#4a4a4f") {
+                    // sets qrCode inner background color if user hasn't selected their own color
+                    qrCode.style.backgroundColor = "rgba(249,249,250,0.8)"; // Photon Grey 90 a80
+                } else {
+                    // otherwise matches qrCode inner background color to user's selected background color
+                    qrCode.style.backgroundColor = qrBackgroundColor;
+                }
+            }
         }
     });
 

--- a/src/popup/modules/UserInterface.js
+++ b/src/popup/modules/UserInterface.js
@@ -533,14 +533,10 @@ export function init() {
         if (qrBackgroundColor) {
             document.body.style.backgroundColor = qrBackgroundColor;
 
-            // checks for OS dark theme and sets appropriate background colors
+            // checks for OS dark theme and sets sets colors in text field
             if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-                // sets dark theme background and text colors in text field
                 qrCodeText.style.backgroundColor = "#4a4a4f"; // Photon Grey 60 -- FF dark theme popup color
                 qrCodeText.style.color = "#ffffff";
-            } else {
-                // otherwise matches qrCode inner background color to user's selected background color
-                qrCode.style.backgroundColor = qrBackgroundColor;
             }
         }
     });

--- a/src/popup/qrcode.css
+++ b/src/popup/qrcode.css
@@ -117,17 +117,3 @@ html, body {
   /* override inerhited from browser-style */
   margin: 0px;
 }
-
-/* shift popup colors if user has specified dark mode (reads preference from OS, not browser) */
-@media (prefers-color-scheme: dark) {
-  .qrcode {
-    background-color: var(--grey-30);
-  }
-  #qrcode-container {
-    background-color: var(--grey-60);
-  }
-  #qrcodetext {
-      background-color: var(--grey-60);
-      color: var(--white-100);
-  }
-}

--- a/src/popup/qrcode.css
+++ b/src/popup/qrcode.css
@@ -118,7 +118,7 @@ html, body {
   margin: 0px;
 }
 
-/* shift popup colors if user has specified dark mode */
+/* shift popup colors if user has specified dark mode (reads preference from OS, not browser) */
 @media (prefers-color-scheme: dark) {
   .qrcode {
     background-color: var(--grey-30);

--- a/src/popup/qrcode.css
+++ b/src/popup/qrcode.css
@@ -121,7 +121,7 @@ html, body {
 /* shift popup colors if user has specified dark mode */
 @media (prefers-color-scheme: dark) {
   .qrcode {
-    background-color: var(--grey-20-a90);
+    background-color: var(--grey-30);
   }
   #qrcode-container {
     background-color: var(--grey-60);

--- a/src/popup/qrcode.css
+++ b/src/popup/qrcode.css
@@ -117,3 +117,17 @@ html, body {
   /* override inerhited from browser-style */
   margin: 0px;
 }
+
+/* shift popup colors if user has specified dark mode */
+@media (prefers-color-scheme: dark) {
+  .qrcode {
+    background-color: var(--grey-20-a90);
+  }
+  #qrcode-container {
+    background-color: var(--grey-60);
+  }
+  #qrcodetext {
+      background-color: var(--grey-60);
+      color: var(--white-100);
+  }
+}


### PR DESCRIPTION
Implements a fix to #186: when a user's OS is set to a dark theme, the popup's colors are shifted to match Firefox's dark theme. 

Note that the fix is implemented using `prefers-color-scheme`, which reads from the OS, not the browser. So a user who's chosen a dark macOS theme, but a light Firefox theme, for example, will still see a popup that's formatted to match FF's dark theme.

Also note that if the OS theme is changed, the browser needs to be restarted for offline-qr-code to reflect that change.