### PR TITLE
Fix scrolling to top robustness

### DIFF
--- a/src/popup/modules/UserInterface.js
+++ b/src/popup/modules/UserInterface.js
@@ -149,14 +149,13 @@ function selectAllText(event) {
     // re-selecting when already selected, causes flashing, so we avoid that
     if (!targetIsSelected) {
         event.target.focus();
-        event.target.select();
-
-        // but set scroll position to top one, because you want to see the
-        // top of the URL ;)
-        // (selecting makes the scroll position go to the bottom)
-        
+        event.target.select(); 
     }
     
+    // set scroll position to top one, because you want to see the
+    // start of an URL
+    // (selecting makes the scroll position go to the bottom)
+
     setTimeout(scrollToTop, TOP_SCROLL_TIMEOUT, event);
 }
 
@@ -171,13 +170,6 @@ function selectAllText(event) {
 function scrollToTop(event) {
     console.info("scrollToTop", event); 
     event.target.scrollTo(0,0);
-  
-    // only retry once, if needed
-    if (event.setScrolled) {
-        return;
-    }
-
-    event.setScrolled = true;
 }
 
 /**

--- a/src/popup/modules/UserInterface.js
+++ b/src/popup/modules/UserInterface.js
@@ -23,7 +23,7 @@ import * as QrError from "./QrLib/QrError.js";
 import * as QrCreator from "./QrCreator.js";
 import {createMenu} from "/common/modules/ContextMenu.js";
 
-const TOP_SCROLL_TIMEOUT = 10; // ms
+const TOP_SCROLL_TIMEOUT = 20; // ms
 const QR_CODE_REFRESH_TIMEOUT = 200; // ms
 const QR_CODE_CONTAINER_MARGIN = 40; // px
 const QR_CODE_SIZE_SNAP = 5; // px
@@ -154,8 +154,10 @@ function selectAllText(event) {
         // but set scroll position to top one, because you want to see the
         // top of the URL ;)
         // (selecting makes the scroll position go to the bottom)
-        setTimeout(scrollToTop, TOP_SCROLL_TIMEOUT, event);
+        
     }
+    
+    setTimeout(scrollToTop, TOP_SCROLL_TIMEOUT, event);
 }
 
 /**
@@ -167,12 +169,9 @@ function selectAllText(event) {
  * @returns {void}
  */
 function scrollToTop(event) {
-    console.info("scrollToTop", event);
-
-    if (event.target.scrollTop !== 0) {
-        event.target.scrollTop = 0;
-    }
-
+    console.info("scrollToTop", event); 
+    event.target.scrollTo(0,0);
+  
     // only retry once, if needed
     if (event.setScrolled) {
         return;


### PR DESCRIPTION
Fixed #203 by making sure scrollToTop was always called and increasing
TOP_SCROLL_TIMEOUT.

setTimeout(scrollToTop, TOP_SCROLL_TIMEOUT, event); was present in an if
statement so it was not always getting called and when it was getting
called, it didn't have enough time to scroll to the top, so to fix this -

1) the setTimeout was moved out of the if statement and

2) TOP_SCROLL_TIMEOUT was increased to 20ms.