### PR TITLE
French translations fixes

### DIFF
--- a/assets/texts/fr/Changelog/1.7.html
+++ b/assets/texts/fr/Changelog/1.7.html
@@ -1,12 +1,12 @@
 <ul>
-<li><strong>Nouveau :</strong> Grâce à une nouvelle librarie de génération de QR Code, vous pouvez maintenant toujours sauvegarder le QR comme PNG ou SVG. Le paramètre pour choisir entre ces deux modes a été retiré des options. (<a href="https://github.com/rugk/offline-qr-code/issues/188">#188</a>)</li>
-<li><strong>Nouveau :</strong> L'extension supporte maintenant le mode "dark" du système. (<a href="https://github.com/rugk/offline-qr-code/issues/186">#186</a>, <a href="https://github.com/rugk/offline-qr-code/issues/190">#190</a>, merci à <a href="https://github.com/davidfloyd91">@davidfloyd91</a>)</li>
-<li><strong>Nouveau :</strong> La traduction vers le chinois (traditionnel) a été ajoutée, grâce à <a href="https://github.com/niotw">@Nio</a>.</li>
-<li><strong>Nouveau :</strong> La traduction vers l'hébreux a été ajoutée, grâce à <a href="https://github.com/shanirub">@shanirub</a>.</li>
-<li><strong>Nouveau:</strong> La traduction vers le japonais a été ajoutée, grâce à <a href="https://github.com/fluoros-jp">@fluoros-jp</a>.</li>
-<li><strong>Nouveau:</strong> La traduction vers le portugais a été ajoutée, grâce à <a href="https://github.com/CGReinhold">@CGReinhold</a>.</li>
-<li><strong>Nouveau:</strong> La traduction vers le russe a été ajoutée, grâce à <a href="https://github.com/m1ndm1n3r">@m1ndm1n3r</a>.</li>
-<li><strong>Nouveau:</strong> La traduction vers le slovaque a été ajoutée, grâce à <a href="https://github.com/daaAd1">@daaAd1</a>.</li>
+<li><strong>Nouveauté :</strong> Grâce à une nouvelle librarie de génération de QR Code, vous pouvez maintenant toujours sauvegarder le QR comme PNG ou SVG. Le paramètre pour choisir entre ces deux modes a été retiré des options. (<a href="https://github.com/rugk/offline-qr-code/issues/188">#188</a>)</li>
+<li><strong>Nouveauté :</strong> L'extension supporte maintenant le mode "dark" du système. (<a href="https://github.com/rugk/offline-qr-code/issues/186">#186</a>, <a href="https://github.com/rugk/offline-qr-code/issues/190">#190</a>, merci à <a href="https://github.com/davidfloyd91">@davidfloyd91</a>)</li>
+<li><strong>Nouveauté :</strong> La traduction vers le chinois (traditionnel) a été ajoutée, grâce à <a href="https://github.com/niotw">@Nio</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction vers l'hébreux a été ajoutée, grâce à <a href="https://github.com/shanirub">@shanirub</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction vers le japonais a été ajoutée, grâce à <a href="https://github.com/fluoros-jp">@fluoros-jp</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction vers le portugais a été ajoutée, grâce à <a href="https://github.com/CGReinhold">@CGReinhold</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction vers le russe a été ajoutée, grâce à <a href="https://github.com/m1ndm1n3r">@m1ndm1n3r</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction vers le slovaque a été ajoutée, grâce à <a href="https://github.com/daaAd1">@daaAd1</a>.</li>
 </ul>
 
-More information <a href="https://github.com/rugk/offline-qr-code/releases/tag/v1.7">on GitHub</a>.
+Plus d'informations <a href="https://github.com/rugk/offline-qr-code/releases/tag/v1.7">sur GitHub</a>.

--- a/assets/texts/fr/Changelog/1.7.html
+++ b/assets/texts/fr/Changelog/1.7.html
@@ -1,0 +1,12 @@
+<ul>
+<li><strong>Nouveau :</strong> Grâce à une nouvelle librarie de génération de QR Code, vous pouvez maintenant toujours sauvegarder le QR comme PNG ou SVG. Le paramètre pour choisir entre ces deux modes a été retiré des options. (<a href="https://github.com/rugk/offline-qr-code/issues/188">#188</a>)</li>
+<li><strong>Nouveau :</strong> L'extension supporte maintenant le mode "dark" du système. (<a href="https://github.com/rugk/offline-qr-code/issues/186">#186</a>, <a href="https://github.com/rugk/offline-qr-code/issues/190">#190</a>, merci à <a href="https://github.com/davidfloyd91">@davidfloyd91</a>)</li>
+<li><strong>Nouveau :</strong> La traduction vers le chinois (traditionnel) a été ajoutée, grâce à <a href="https://github.com/niotw">@Nio</a>.</li>
+<li><strong>Nouveau :</strong> La traduction vers l'hébreux a été ajoutée, grâce à <a href="https://github.com/shanirub">@shanirub</a>.</li>
+<li><strong>Nouveau:</strong> La traduction vers le japonais a été ajoutée, grâce à <a href="https://github.com/fluoros-jp">@fluoros-jp</a>.</li>
+<li><strong>Nouveau:</strong> La traduction vers le portugais a été ajoutée, grâce à <a href="https://github.com/CGReinhold">@CGReinhold</a>.</li>
+<li><strong>Nouveau:</strong> La traduction vers le russe a été ajoutée, grâce à <a href="https://github.com/m1ndm1n3r">@m1ndm1n3r</a>.</li>
+<li><strong>Nouveau:</strong> La traduction vers le slovaque a été ajoutée, grâce à <a href="https://github.com/daaAd1">@daaAd1</a>.</li>
+</ul>
+
+More information <a href="https://github.com/rugk/offline-qr-code/releases/tag/v1.7">on GitHub</a>.

--- a/assets/texts/fr/Changelog/1.7.html
+++ b/assets/texts/fr/Changelog/1.7.html
@@ -1,12 +1,12 @@
 <ul>
 <li><strong>Nouveauté :</strong> Grâce à une nouvelle librarie de génération de QR Code, vous pouvez maintenant toujours sauvegarder le QR comme PNG ou SVG. Le paramètre pour choisir entre ces deux modes a été retiré des options. (<a href="https://github.com/rugk/offline-qr-code/issues/188">#188</a>)</li>
-<li><strong>Nouveauté :</strong> L'extension supporte maintenant le mode "dark" du système. (<a href="https://github.com/rugk/offline-qr-code/issues/186">#186</a>, <a href="https://github.com/rugk/offline-qr-code/issues/190">#190</a>, merci à <a href="https://github.com/davidfloyd91">@davidfloyd91</a>)</li>
-<li><strong>Nouveauté :</strong> La traduction vers le chinois (traditionnel) a été ajoutée, grâce à <a href="https://github.com/niotw">@Nio</a>.</li>
-<li><strong>Nouveauté :</strong> La traduction vers l'hébreux a été ajoutée, grâce à <a href="https://github.com/shanirub">@shanirub</a>.</li>
-<li><strong>Nouveauté :</strong> La traduction vers le japonais a été ajoutée, grâce à <a href="https://github.com/fluoros-jp">@fluoros-jp</a>.</li>
-<li><strong>Nouveauté :</strong> La traduction vers le portugais a été ajoutée, grâce à <a href="https://github.com/CGReinhold">@CGReinhold</a>.</li>
-<li><strong>Nouveauté :</strong> La traduction vers le russe a été ajoutée, grâce à <a href="https://github.com/m1ndm1n3r">@m1ndm1n3r</a>.</li>
-<li><strong>Nouveauté :</strong> La traduction vers le slovaque a été ajoutée, grâce à <a href="https://github.com/daaAd1">@daaAd1</a>.</li>
+<li><strong>Nouveauté :</strong> L'extension supporte maintenant le mode sombre (dark) du système. (<a href="https://github.com/rugk/offline-qr-code/issues/186">#186</a>, <a href="https://github.com/rugk/offline-qr-code/issues/190">#190</a>, merci à <a href="https://github.com/davidfloyd91">@davidfloyd91</a>)</li>
+<li><strong>Nouveauté :</strong> La traduction en chinois (traditionnel) a été ajoutée, grâce à <a href="https://github.com/niotw">@Nio</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction en hébreux a été ajoutée, grâce à <a href="https://github.com/shanirub">@shanirub</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction en japonais a été ajoutée, grâce à <a href="https://github.com/fluoros-jp">@fluoros-jp</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction en portugais a été ajoutée, grâce à <a href="https://github.com/CGReinhold">@CGReinhold</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction en russe a été ajoutée, grâce à <a href="https://github.com/m1ndm1n3r">@m1ndm1n3r</a>.</li>
+<li><strong>Nouveauté :</strong> La traduction en slovaque a été ajoutée, grâce à <a href="https://github.com/daaAd1">@daaAd1</a>.</li>
 </ul>
 
 Plus d'informations <a href="https://github.com/rugk/offline-qr-code/releases/tag/v1.7">sur GitHub</a>.

--- a/assets/texts/fr/Changelog/1.7.html
+++ b/assets/texts/fr/Changelog/1.7.html
@@ -1,5 +1,5 @@
 <ul>
-<li><strong>Nouveauté :</strong> Grâce à une nouvelle librarie de génération de QR Code, vous pouvez maintenant toujours sauvegarder le QR comme PNG ou SVG. Le paramètre pour choisir entre ces deux modes a été retiré des options. (<a href="https://github.com/rugk/offline-qr-code/issues/188">#188</a>)</li>
+<li><strong>Nouveauté :</strong> Grâce à une nouvelle bibliothèque de génération de QR Code, vous pouvez maintenant toujours sauvegarder le QR comme PNG ou SVG. Le paramètre pour choisir entre ces deux modes a été retiré des options. (<a href="https://github.com/rugk/offline-qr-code/issues/188">#188</a>)</li>
 <li><strong>Nouveauté :</strong> L'extension supporte maintenant le mode sombre (dark) du système. (<a href="https://github.com/rugk/offline-qr-code/issues/186">#186</a>, <a href="https://github.com/rugk/offline-qr-code/issues/190">#190</a>, merci à <a href="https://github.com/davidfloyd91">@davidfloyd91</a>)</li>
 <li><strong>Nouveauté :</strong> La traduction en chinois (traditionnel) a été ajoutée, grâce à <a href="https://github.com/niotw">@Nio</a>.</li>
 <li><strong>Nouveauté :</strong> La traduction en hébreux a été ajoutée, grâce à <a href="https://github.com/shanirub">@shanirub</a>.</li>

--- a/assets/texts/fr/Changelog/1.7.md
+++ b/assets/texts/fr/Changelog/1.7.md
@@ -1,1 +1,1 @@
-* **Fixé:** Amélioré la robustesse du défilement du texte vers le haut lors de la saisie ([#203](https://github.com/rugk/offline-qr-code/issues/203), thanks [@pradyumnamahajan](https://github.com/pradyumnamahajan))
+* **Amélioration :** La robustesse du défilement du texte vers le haut lors de la saisie a été améliorée ([#203](https://github.com/rugk/offline-qr-code/issues/203), thanks [@pradyumnamahajan](https://github.com/pradyumnamahajan))

--- a/assets/texts/fr/Changelog/1.7.md
+++ b/assets/texts/fr/Changelog/1.7.md
@@ -1,0 +1,1 @@
+* **Fixé:** Amélioré la robustesse du défilement du texte vers le haut lors de la saisie ([#203](https://github.com/rugk/offline-qr-code/issues/203), thanks [@pradyumnamahajan](https://github.com/pradyumnamahajan))

--- a/assets/texts/fr/amoDescription.html
+++ b/assets/texts/fr/amoDescription.html
@@ -1,38 +1,36 @@
-À la différence de nombreuses extensions qui utilisent les Google Web APIs pour générer des QR-Codes, cette extension fonctionne totalement hors-ligne. <b>Ce générateur de QR-Code place ta vie privée au premier plan ! 🔐</b>
+À la différence de nombreuses extensions qui utilisent les Google Web APIs pour générer des QR-Codes, cette extension fonctionne totalement hors-ligne. <b>Ce générateur de QR-Code place votre vie privée au premier plan ! 🔐</b>
 Cela en fonctionnant totalement <em>hors-ligne</em>, indépendemment de toute connection à internet ! Toujours.
 
 
-<b>👌 Si simple, tu peux l'utiliser en un clic ! 👌</b>
+<b>👌 Si simple, vous pouvez l'utiliser en un clic ! 👌</b>
+Elle utilise une interface <b>simple, mais puissante</b>, vous permettant de paramétrer une multitude d'options dans les réglages, tout en restant très simple d'utilisation! Par exemple, vous pouvez <b>redimmensionner le QR code</b> avec votre souris par glisser-déposer. Étant <b>légère</b> et ayant une faible taille la rend rapide et simple à installer – même en connexion mobile.
 
-It has a radically <b>simple, yet powerful</b> user interface, allowing you to tweak many details in the settings. Nevertheless, it's really easy to use! For instance, you can <b>just resize the QR code</b> with your mouse by dragging and dropping. Being <b>lightweight</b> and thus having a small size it is also fast and easy to install – even on mobile connections.
-
-
-<b>📦 Génère une diversité de QR-Codes! 📦</b>
-Génère des QR-Codes <b>colorés</b>, <b>enregistre</b> les QR-Codes ou utilise les pour envoyer un onglet ou un autre texte de ton ordinateur vers ton mobile ! Tu as le choix !
-Ton QR-Code sera <b>à portée de clic</b> et tu peux instantanément commencer à taper pour changer le texte du QR-Code !
+<b>📦 Générez une diversité de QR-Codes! 📦</b>
+Générez des QR-Codes <b>colorés</b>, <b>enregistrez</b> les QR-Codes ou utilisez-les pour envoyer un onglet ou un autre texte de votre ordinateur vers votre mobile ! Vous avez le choix !
+Votre QR-Code sera <b>à portée de clic</b> et vous pouvez instantanément commencer à taper pour changer le texte du QR-Code !
 
 
 <b>📢 Plus de fonctionnalités 📢</b>
 <ul>
-<li>Met ta vie privée au premier plan ! La confidentialité est la base ici, donc on génère les QR-Codes hors-ligne.</li>
+<li>Place votre vie privée au premier plan ! La confidentialité est la base ici, donc on génère les QR-Codes hors-ligne.</li>
 <li>Suit le <a href="https://design.firefox.com/photon/">Firefox Photon Design</a> pour s'intégrer facilement dans le design de ton Firefox.</li>
 <li>C'est super simple et l'utilisation est intuitive !</li>
 <li>Utilise des <a href="https://larsjung.de/kjua/">libraries</a> de <a href="https://github.com/werthdavid/kjua">QR code</a> à jour, géniales, and customisables pour générer les QR-Codes.</li>
-<li>Tu peux générer et enregistrer des QR-Codes au format SVG ou en tant qu'image PNG ("Canvas") !</li>
-<li>Tu peux configurer la taille, la couleur et d'autres aspects du QR-Code.</li>
+<li>Vous pouvez générer et enregistrer des QR-Codes au format SVG ou en tant qu'image PNG ("Canvas") !</li>
+<li>Vous pouvez configurer la taille, la couleur et d'autres aspects du QR-Code.</li>
 <li>Utilise un raccourci (Ctrl+Maj+F10) pour générer le QR-Code.</li>
 <li>Génère des QR-Codes à partir de texte sélectionné sur le site web.</li>
 <li>Supporte totalement les caractères Unicode/UTF-8/Emoji.</li>
-<li>C'est esthétique sur ordinateur et sur mobile, c'est responsive!</li>
-<li>Déjà traduit dans plusieurs langues. Tu peux <a href="https://github.com/rugk/offline-qr-code/blob/master/CONTRIBUTING.md#translations">contribuer à ta propre langue !</a></li>
+<li>Est esthétique sur ordinateur et sur mobile, c'est responsive!</li>
+<li>Déjà traduit dans plusieurs langues. Vous pouvez <a href="https://github.com/rugk/offline-qr-code/blob/master/CONTRIBUTING.md#translations">contribuer à traduire dans votre propre langue !</a></li>
 <li>Compatible avec Firefox pour Android</li>
 <li>Les paramètres sont synchronisés entre les appareils.</li>
-<li>Les paramètres peuvent être gérés par ton administateur. (en cours de développement)</li>
+<li>Les paramètres peuvent être gérés par votre administateur. (en cours de développement)</li>
 </ul>
 
 
 <b>📝 Développement 📝</b>
-Cette extension est gratuite, libre et open-source, et développée sur GitHub. <a href="https://github.com/rugk/offline-qr-code">Fork le dépôt GitHub</a> et contribue.
+Cette extension est gratuite, libre et open-source, et développée sur GitHub. <a href="https://github.com/rugk/offline-qr-code">Forkez le dépôt GitHub</a> et contribuez.
 <a href="https://github.com/rugk/offline-qr-code/contribute">Il y a des issues faciles pour débuter.</a>
 
 Le nom anglais original de l'extension est « Offline QR Code Generator ».

--- a/assets/texts/fr/amoDescription.html
+++ b/assets/texts/fr/amoDescription.html
@@ -3,7 +3,7 @@ Cela en fonctionnant totalement <em>hors-ligne</em>, indépendemment de toute co
 
 
 <b>👌 Si simple, vous pouvez l'utiliser en un clic ! 👌</b>
-Elle utilise une interface <b>simple, mais puissante</b>, vous permettant de paramétrer une multitude d'options dans les réglages, tout en restant très simple d'utilisation! Par exemple, vous pouvez <b>redimmensionner le QR code</b> avec votre souris par glisser-déposer. Étant <b>légère</b> et ayant une faible taille la rend rapide et simple à installer – même en connexion mobile.
+Elle utilise une interface <b>simple, mais puissante</b>, vous permettant de paramétrer une multitude d'options dans les réglages, tout en restant très simple d'utilisation! Par exemple, vous pouvez <b>redimensionner le QR code</b> avec votre souris par glisser-déposer. Étant <b>légère</b> et ayant une faible taille la rend rapide et simple à installer – même en connexion mobile.
 
 <b>📦 Générez une diversité de QR-Codes! 📦</b>
 Générez des QR-Codes <b>colorés</b>, <b>enregistrez</b> les QR-Codes ou utilisez-les pour envoyer un onglet ou un autre texte de votre ordinateur vers votre mobile ! Vous avez le choix !

--- a/assets/texts/fr/amoScreenshots.csv
+++ b/assets/texts/fr/amoScreenshots.csv
@@ -1,4 +1,4 @@
-AqrBig.png; "Les QR-Codes sont redimensionnables !";
+qrBig.png; "Les QR-Codes sont redimensionnables !";
 qrDark.png; "Vous pouvez ajuster le QR-Code à votre thème.";
 qrMenuFromLink.png; "Vous pouvez créer des QR-Codes directement à partir de liens."
 qrMenuFromPhoneNumber.png; "Vous pouvez créer des QR-Codes directement à partir du texte sélectionné."

--- a/assets/texts/fr/amoScreenshots.csv
+++ b/assets/texts/fr/amoScreenshots.csv
@@ -1,8 +1,8 @@
-qrBig.png; "Les QR-Codes sont redimensionnables !";
-qrDark.png; "Tu peux ajuster le QR-Code à ton thème.";
-qrMenuFromLink.png; "Tu peux créer des QR-Codes directement à partir de liens."
-qrMenuFromPhoneNumber.png; "Tu peux créer des QR-Codes directement à partir du texte sélectionné."
-qrSaveSvg.png; "Tu peux enregistrer des QR-Codes en SVGs ou PNGs.";
-qrSettings.png; "Plusieurs options te permettent de personnaliser le comportement et l'apparence.";
+AqrBig.png; "Les QR-Codes sont redimensionnables !";
+qrDark.png; "Vous pouvez ajuster le QR-Code à votre thème.";
+qrMenuFromLink.png; "Vous pouvez créer des QR-Codes directement à partir de liens."
+qrMenuFromPhoneNumber.png; "Vous pouvez créer des QR-Codes directement à partir du texte sélectionné."
+qrSaveSvg.png; "Vous pouvez enregistrer des QR-Codes en SVGs ou PNGs.";
+qrSettings.png; "Plusieurs options vous permettent de personnaliser le comportement et l'apparence.";
 qrSmall.png; "Les QR-Codes peuvent être générés avec n'importe quelle taille.";
-qrText.png; "Tape du texte personnalisé après avoir clické sur le bouton pour générer un nouveau QR-Code à la volée.";
+qrText.png; "Tapez du texte personnalisé après avoir cliqué sur le bouton pour générer un nouveau QR-Code à la volée.";

--- a/assets/texts/fr/amoSummary.txt
+++ b/assets/texts/fr/amoSummary.txt
@@ -1,3 +1,3 @@
-Cette extension te permet de générer rapidemment un QR-Code avec l'URL du site de l'onglet actuel, ou n'importe quel texte (sélectionné), le tout hors-ligne ! 👍
+Cette extension vous permet de générer rapidemment un QR-Code avec l'URL du site de l'onglet actuel, ou n'importe quel texte (sélectionné), le tout hors-ligne ! 👍
 
-Cela fonctionne totalement hors-ligne pour protéger ta vie privée!
+Cela fonctionne totalement hors-ligne pour protéger votre vie privée!

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -11,7 +11,7 @@
     "hash": "a38edae757cf4b1c8a57c0de97ae7400"
   },
   "extensionDescription": {
-    "message": "Te permet de générer un QR-Code pour n'importe quel site ou onglet que tu as ouvert.",
+    "message": "Vous permet de générer un QR-Code pour n'importe quel site ou onglet ouvert.",
     "description": "Description of the extension.",
     "hash": "824ef7416ba4361e3621df1fe8048c3b"
   },
@@ -107,7 +107,7 @@
     "hash": "6e5a5fe9a077400ba6e4dc66a6dfd44a"
   },
   "lowContrastRatioInfo": {
-    "message": "Ton QR-Code peut être difficile à scanner par d'autres lecteurs de QR-Code à cause du faible contraste.",
+    "message": "Votre QR-Code peut être difficile à scanner par d'autres lecteurs de QR-Code à cause du faible contraste.",
     "hash": "90432f33baa13153accd007ae2e23e99"
   },
   "lowContrastRatioWarning": {
@@ -120,24 +120,24 @@
     "hash": "a2d1d2fdc32ecb73ffdf0ab537e46f32"
   },
   "messageAutoSelectColorButton": {
-    "message": "Utilise des couleurs en contraste.",
+    "message": "Utilisez des couleurs contrastée.",
     "description": "The text of a button that sets a new color with a sufficient contrast.",
     "hash": "9d422df9f61f2b45e272ae3451ca3ded"
   },
 
   // tips
   "tipYouLikeAddon": {
-    "message": "Tu aimes cette extension ?",
+    "message": "Vous appréciez cette extension ?",
     "description": "A tip shown to remind the user to rate the addon.",
     "hash": "0f5680a5a42bcebf793a44b9dfcf79a1"
   },
   "tipYouLikeAddonButton": {
-    "message": "Note-la",
+    "message": "Notez-la",
     "description": "Button for the tip shown to remind the user to rate the addon.",
     "hash": "821d7f942b02e2b56cd0424d3ab65de8"
   },
   "tipSaveQrCode": {
-    "message": "Savais-tu que tu peux enregistrer des QR-Codes ?",
+    "message": "Saviez-vous que vous pouviez enregistrer des QR-Codes ?",
     "description": "A tip shown to get the user to find the save option.",
     "hash": "84f0a0027a58c98d9158ab9894fe8427"
   },
@@ -147,7 +147,7 @@
     "hash": "c453089f62132ffa4151c4487209de69"
   },
   "tipQrCodeHotkey": {
-    "message": "Souviens toi que la combinaison de touches pour cette extension est Ctrl+Maj+F10.",
+    "message": "N'oubliez pas, la combinaison de touches pour cette extension est Ctrl+Maj+F10.",
     "description": "A tip shown to get the user to notice that there is a hot key.",
     "hash": "a372dc813085fe800ecb594e33b6c81c"
   },
@@ -162,7 +162,7 @@
     "hash": "094c1bbce6c3a7bcb09f36b7bc970dd0"
   },
   "tipTranslateAddon": {
-    "message": "Si tu parles une autre langue, tu peux nous aider à traduire cette extension.",
+    "message": "Si vous parlez une autre langue, vous pouvez nous aider à traduire cette extension.",
     "description": "A tip shown to users that potentially speak another language to translate this add-on.",
     "hash": "f22661cb0e9cdc8144d0c3cf59f854e3"
     },
@@ -172,12 +172,12 @@
     "hash": "b0421380ecfc4481fd5ee9da72c61516"
   },
   "tipDonate": {
-    "message": "Tu aimes utiliser cette extension gratuitement ?",
+    "message": "Vous aimez utiliser cette extension gratuitement ?",
     "description": "A tip shown to get the remind them of a donation.",
     "hash": "1ca77d6621635ae0bec563e15fbc3791"
   },
     "tipDonateButton": {
-    "message": "Soutiens le développement en faisant un don",
+    "message": "Soutenez le développement en faisant un don",
     "description": "The button of the donation tip taking the user to the donation site.",
     "hash": "8ec498495b752c6d9358208a5564d42c"
   },
@@ -199,7 +199,7 @@
     "hash": "2aad56747125ef1f986b5d952ba68a83"
   },
   "textareaPlaceholder": {
-    "message": "Saisis du texte ici pour générer le QR-Code.",
+    "message": "Saisissez du texte ici pour générer le QR-Code.",
     "description": "Placeholder for the textarea, when it is empty.",
     "hash": "0d0f6b3baffcdbf22a78418b3460d1ad"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -120,7 +120,7 @@
     "hash": "a2d1d2fdc32ecb73ffdf0ab537e46f32"
   },
   "messageAutoSelectColorButton": {
-    "message": "Utilisez des couleurs contrastée.",
+    "message": "Utilisez des couleurs contrastées.",
     "description": "The text of a button that sets a new color with a sufficient contrast.",
     "hash": "9d422df9f61f2b45e272ae3451ca3ded"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -120,7 +120,7 @@
     "hash": "a2d1d2fdc32ecb73ffdf0ab537e46f32"
   },
   "messageAutoSelectColorButton": {
-    "message": "Utilisez des couleurs contrastées.",
+    "message": "Utiliser des couleurs contrastées.",
     "description": "The text of a button that sets a new color with a sufficient contrast.",
     "hash": "9d422df9f61f2b45e272ae3451ca3ded"
   },


### PR DESCRIPTION
Using the polite form ('vous') rather than the familiar form ('tu'), which sounds childish to the ear.
Also updated the 1.7 changelog.
Thank you for this extension! 🏄