### PR TITLE
Added feature to copy QR to clipboard

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -202,6 +202,15 @@
     "message": "Save QR code as an &SVG…",
     "description": "The context menu entry shown for saving SVG images in the popup with an access key."
   },
+  "contextMenuSaveImageClipboard": {
+    "message": "Save QR code to clipboard…",
+    "description": "The context menu entry shown for saving PNG images (to the clipboard) in the popup"
+  },
+  "contextMenuSaveImageClipboardAccessKey": {
+    "message": "Save QR code to &clipboard…",
+    "description": "The context menu entry shown for saving PNG images (to the clipboard) in the popup with an access key."
+  },
+
 
   // options
   "someSettingsAreManaged": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -362,6 +362,11 @@
     "description": "This is an option shown in the add-on settings."
   },
 
+  "optionOverrideCopy": {
+    "message": "CTRL+C/⌘+C to copy QR code",
+    "description": "This is an option shown in the add-on"
+  },
+
   "optionDebugMode": {
     "message": "Enable debug mode",
     "description": "This is an option shown in the add-on settings."

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -29,7 +29,8 @@ const defaultSettings = Object.freeze({
     qrQuietZone: 1,
     randomTips: {
         tips: {}
-    }
+    },
+    overrideCopy: true
 });
 
 // freeze the inner objects, this is strongly recommend

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -181,6 +181,13 @@
 
 					<li>
 						<div class="line">
+							<input class="setting save-on-change" type="checkbox" id="overrideCopy" name="overrideCopy">
+							<label data-i18n="__MSG_optionOverrideCopy__" for="overrideCopy">CTRL+C/⌘+C to copy QR code</label>
+						</div>
+					</li>
+
+					<li>
+						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">
 							<label data-i18n="__MSG_optionDebugMode__" for="debugMode">Enable debug mode</label>
 						</div>


### PR DESCRIPTION
This closes #285 but it has a caveat. This is because I used the Clipboard API in order to copy the QR code to the clipboard, which does not work by default [in the current Firefox release](https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem). There is another way to implement this using `document.execCommand('copy')` [like this one](https://stackoverflow.com/a/40547470), but I couldn't get it to work.

When you set `dom.events.asyncClipboard.clipboardItem` to `true` in `about:config` this functions works fine. The issue that is blocking it from [ being activated by default](https://bugzilla.mozilla.org/show_bug.cgi?id=1809106) is [being worked on](https://bugzilla.mozilla.org/show_bug.cgi?id=1712122), so this suggests that the required `about:config` entry might be activated by default some time in the future.

I'm not sure on how to proceed with this, should we maybe add a small description in the options to let users know how to activate it with the current (stable) version of Firefox?

Also, I tested this function on both Windows 11 22H2 and macOS Ventura 13.3 on Firefox 111.0.1 and 112.0b8 (Developer Edition) by pasting the copied image to LibreOffice Writer, which worked fine on both platforms and versions of Firefox.

If something needs to change or is a bit unclear, please let me know, I'll get back to you ASAP.