### PR TITLE
[Fix] error # 309 (moved the undo button below reset button)

### DIFF
--- a/src/options/options.html
+++ b/src/options/options.html
@@ -29,13 +29,7 @@
 				</a>
 				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
 			</div>
-			<div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide">
-				<span class="message-text">That worked!</span>
-				<a href="#">
-					<button type="button" class="message-action-button micro-button success invisible"></button>
-				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-			</div>
+			
 			<div id="messageError" aria-label="error message" data-i18n data-i18n-aria-label="__MSG_ariaMessageError__" class="message-box error invisible fade-hide">
 				<span class="message-text">An error happened.</span>
 				<a href="#">
@@ -194,6 +188,13 @@
 			<div>
 				<hr /><br />
 				<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
+			</div>
+			<div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide success-undo-message-box">
+				<span class="message-text">That worked!</span>
+				<a href="#">
+					<button type="button" class="message-action-button micro-button success invisible"></button>
+				</a>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
 			</div>
 		</form>
 		<p class="helper-text">


### PR DESCRIPTION
Moved the code for undo banner below the reset button. Created a css class to provide a 10px margin above the reset button

[cinnamon-2023-08-19T155310+0530.webm](https://github.com/rugk/offline-qr-code/assets/115188127/5a5ab74a-8e9a-4d2c-a41f-d254b38ec2dc)
