### PR TITLE
Fix issue #309

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
 - Metta Ong ([@ongspxm](https://github.com/ongspxm))
 - Michael Corwin ([@mcorwin22](https://github.com/mcorwin22))
 - Pradyumna Mahajan ([@pradyumnamahajan](https://github.com/pradyumnamahajan))
+- Aadarsh Jha ([@renji18](https://github.com/renji18))
 
 ## Translators
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -29,13 +29,7 @@
 				</a>
 				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
 			</div>
-			<div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide">
-				<span class="message-text">That worked!</span>
-				<a href="#">
-					<button type="button" class="message-action-button micro-button success invisible"></button>
-				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
-			</div>
+			
 			<div id="messageError" aria-label="error message" data-i18n data-i18n-aria-label="__MSG_ariaMessageError__" class="message-box error invisible fade-hide">
 				<span class="message-text">An error happened.</span>
 				<a href="#">
@@ -194,6 +188,13 @@
 			<div>
 				<hr /><br />
 				<button data-i18n="__MSG_optionsResetButton__" type="button" id="resetButton">Reset all settings to defaults</button>
+			</div>
+			<div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide success-undo-message-box">
+				<span class="message-text">That worked!</span>
+				<a href="#">
+					<button type="button" class="message-action-button micro-button success invisible"></button>
+				</a>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
 			</div>
 		</form>
 		<p class="helper-text">


### PR DESCRIPTION
Moved the code for undo banner below the reset button. Created a css class to add some margin between the banner and button

[cinnamon-2023-08-19T155310+0530.webm](https://github.com/rugk/offline-qr-code/assets/115188127/06963b29-09c2-4a9f-8834-60247c80f273)
