### PR TITLE
Add context-menu item for generating QR code for the current page (#321)

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
 - Metta Ong ([@ongspxm](https://github.com/ongspxm))
 - Michael Corwin ([@mcorwin22](https://github.com/mcorwin22))
 - Pradyumna Mahajan ([@pradyumnamahajan](https://github.com/pradyumnamahajan))
+- Mahmoud Ayesh ([@mahmoudhusam](https://github.com/mahmoudhusam))
 
 ## Translators
 

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -186,6 +186,14 @@
     "message": "&QR-Code aus Link",
     "description": "The context menu entry shown for generating QR codes from a selected link with an access key."
   },
+  "contextMenuItemConvertPageURL": {
+    "message": "Generiere QR-Code für diese Seite",
+    "description": "Context menu item title for generating a QR code for the current page URL."
+  },
+  "contextMenuItemConvertPageURLAccessKey": {
+    "message": "&Generiere QR-Code für diese Seite",
+    "description": "Context menu item title for generating a QR code for the current page URL with an access key."
+  },
   "contextMenuSaveImageCanvas": {
     "message": "QR-Code als Bild speichern…",
     "description": "The context menu entry shown for saving SVG images in the popup."
@@ -240,6 +248,14 @@
   "optionPopupIconColoredDescr": {
     "message": "Zeigt ein farbiges Icon anstatt eines schwarz/weißen Icons in der Toolbar.",
     "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."
+  },
+  "optionContextMenuEnabled": {
+    "message": "Zeige allgemeinen QR-Code-Generierungs-Kontextmenü-Eintrag",
+    "description": "This label refers to an option in the add-on settings. It allows users to toggle the visibility of the context menu item for generating a QR code from the current page."
+  },
+  "optionContextMenuEnabledDescr": {
+    "message": "Zeigt einen Kontextmenü-Eintrag um QR-Codes für die aktuelle Seite zu erstellen, zusätzlich zu denen für Links und ausgewählten Text.",
+    "description": "This is the helper text for the context menu toggle option. It explains that enabling this option will show the QR code generation context menu for the current page."
   },
 
   "subtitleQrCodeSize": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -250,6 +250,14 @@
     "message": "Shows a colored icon instead of the black/white icon in the toolbar.",
     "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."
   },
+  "contextMenuEnabled": {
+    "message": "Enable QR code context menu item",
+    "description": "Toggle to show or hide the context menu item for generating a QR code for the current page."
+  },
+  "contextMenuEnabledDescr": {
+    "message": "Enabling this option allows you to create a QR code for the current page using the context menu.",
+    "description": "Detailed description of the contextMenuEnabled setting."
+  },
 
   "subtitleQrCodeSize": {
     "message": "QR code size",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -187,11 +187,11 @@
     "description": "The context menu entry shown for generating QR codes from a selected link with an access key."
   },
   "contextMenuItemConvertPageURL": {
-    "message": "Generate QR Code for this Page",
+    "message": "Generate QR code for this page",
     "description": "Context menu item title for generating a QR code for the current page URL."
   },
   "contextMenuItemConvertPageURLAccessKey": {
-    "message": "&Generate QR Code for this Page",
+    "message": "&Generate QR code for this page",
     "description": "Context menu item title for generating a QR code for the current page URL with an access key."
   },
   "contextMenuSaveImageCanvas": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -250,13 +250,13 @@
     "message": "Shows a colored icon instead of the black/white icon in the toolbar.",
     "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."
   },
-  "contextMenuEnabled": {
-    "message": "Enable QR code context menu item",
-    "description": "Toggle to show or hide the context menu item for generating a QR code for the current page."
+  "optionContextMenuEnabled": {
+    "message": "Show general QR code generation context menu item",
+    "description": "This label refers to an option in the add-on settings. It allows users to toggle the visibility of the context menu item for generating a QR code from the current page."
   },
-  "contextMenuEnabledDescr": {
-    "message": "Enabling this option allows you to create a QR code for the current page using the context menu.",
-    "description": "Detailed description of the contextMenuEnabled setting."
+  "optionContextMenuEnabledDescr": {
+    "message": "Shows a context menu item to create QR code for the current page, in addition to links and text selections.",
+    "description": "This is the helper text for the context menu toggle option. It explains that enabling this option will show the QR code generation context menu for the current page."
   },
 
   "subtitleQrCodeSize": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -186,6 +186,14 @@
     "message": "&QR code from link",
     "description": "The context menu entry shown for generating QR codes from a selected link with an access key."
   },
+  "contextMenuItemConvertPageURL": {
+    "message": "Generate QR Code for this Page",
+    "description": "Context menu item title for generating a QR code for the current page URL."
+  },
+  "contextMenuItemConvertPageURLAccessKey": {
+    "message": "&Generate QR Code for this Page",
+    "description": "Context menu item title for generating a QR code for the current page URL with an access key."
+  },
   "contextMenuSaveImageCanvas": {
     "message": "Save QR code as an image…",
     "description": "The context menu entry shown for saving PNG images (from a canvas) in the popup."

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -61,6 +61,17 @@ function createItems() {
         contexts: ["page"]
     });
 
+    browser.runtime.onMessage.addListener((message) => {
+        if (message.action === "enableContextMenu") {
+            browser.menus.update(CONVERT_PAGE_URL, { visible: true });
+            console.log("Context menu enabled");
+        } else if (message.action === "disableContextMenu") {
+            browser.menus.update(CONVERT_PAGE_URL, { visible: false });
+            console.log("Context menu disabled");
+        }
+        browser.menus.refresh();
+    });
+    
     browser.menus.refresh();
 
     // if listener is set, because items were hidden -> remove it
@@ -97,7 +108,7 @@ function menuClicked(event) {
     case CONVERT_PAGE_URL:
         browser.browserAction.openPopup().then(() => {
             messageResentCount = 0;
-            // Send the current page URL to the popup
+            // Send the current page URL to the popup explicitly to overwrite any setting that may use a different string
             sendQrCodeText(event.pageUrl);
         });
         break;
@@ -132,6 +143,7 @@ function menuShown(info) {
 
     browser.menus.remove(CONVERT_TEXT_SELECTION);
     browser.menus.remove(CONVERT_LINK_TEXT_SELECTION);
+    browser.menus.remove(CONVERT_PAGE_URL);
 
     browser.menus.refresh();
 }

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -61,17 +61,6 @@ function createItems() {
         contexts: ["page"]
     });
 
-    browser.runtime.onMessage.addListener((message) => {
-        if (message.action === "enableContextMenu") {
-            browser.menus.update(CONVERT_PAGE_URL, { visible: true });
-            console.log("Context menu enabled");
-        } else if (message.action === "disableContextMenu") {
-            browser.menus.update(CONVERT_PAGE_URL, { visible: false });
-            console.log("Context menu disabled");
-        }
-        browser.menus.refresh();
-    });
-    
     browser.menus.refresh();
 
     // if listener is set, because items were hidden -> remove it
@@ -160,5 +149,15 @@ export function init() {
     return createItems().then(() => {
         browser.menus.onClicked.addListener(menuClicked);
         browser.menus.onShown.addListener(menuShown);
+        browser.runtime.onMessage.addListener((message) => {
+            if (message.action === "enableContextMenu") {
+                browser.menus.update(CONVERT_PAGE_URL, { visible: true });
+                console.log("Context menu enabled");
+            } else if (message.action === "disableContextMenu") {
+                browser.menus.update(CONVERT_PAGE_URL, { visible: false });
+                console.log("Context menu disabled");
+            }
+            browser.menus.refresh();
+        });    
     });
 }

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -4,6 +4,7 @@ import { createMenu } from "/common/modules/ContextMenu.js";
 const CONVERT_TEXT_SELECTION = "qr-convert-text-selection";
 const CONVERT_LINK_TEXT_SELECTION = "qr-convert-link-text-selection";
 const OPEN_OPTIONS = "qr-open-options";
+const CONVERT_PAGE_URL = "qr-convert-page-url";
 
 const MESSAGE_RESENT_TIMEOUT = 200; // ms
 const MESSAGE_RESENT_MAX = 9;
@@ -55,12 +56,17 @@ function createItems() {
         contexts: ["link"]
     });
 
+    const pageMenu = createMenu("contextMenuItemConvertPageURL", {
+        id: CONVERT_PAGE_URL,
+        contexts: ["page"]
+    });
+
     browser.menus.refresh();
 
     // if listener is set, because items were hidden -> remove it
     browser.menus.onHidden.removeListener(createItems);
 
-    return Promise.all([selectionMenu, linkMenu]);
+    return Promise.all([selectionMenu, linkMenu, pageMenu]);
 }
 
 /**
@@ -86,6 +92,13 @@ function menuClicked(event) {
 
             // send message to popup
             sendQrCodeText(event.linkUrl);
+        });
+        break;
+    case CONVERT_PAGE_URL:
+        browser.browserAction.openPopup().then(() => {
+            messageResentCount = 0;
+            // Send the current page URL to the popup
+            sendQrCodeText(event.pageUrl);
         });
         break;
     case OPEN_OPTIONS:

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -17,6 +17,7 @@ const isDarkTheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
 const defaultSettings = Object.freeze({
     debugMode: false,
     popupIconColored: false,
+    contextMenuEnabled: true,
     qrColor: "#0c0c0d",
     qrBackgroundColor: (isDarkTheme ? "#d7d7db" : "#ffffff"), // dark uses Firefox Photon's grey-30
     qrErrorCorrection: "Q",

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -93,17 +93,6 @@ function applyContextMenuEnabled(optionValue) {
 }
 
 /**
- * Event listener to save the checkbox state and apply it.
- */
-document.getElementById('contextMenuEnabled').addEventListener('change', async (event) => {
-    const isChecked = event.target.checked;
-    await browser.storage.local.set({ contextMenuEnabled: isChecked });
-
-    // Apply the context menu based on the checkbox state
-    applyContextMenuEnabled(isChecked);
-});
-
-/**
  * Adjust UI if QR code size option is changed.
  *
  * @function

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -73,6 +73,37 @@ function applyPopupIconColor(optionValue) {
 }
 
 /**
+ * Adjusts UI based on the state of context menu enabled option.
+ *
+ * @function
+ * @private
+ * @param {boolean} optionValue
+ * @returns {void}
+ */
+function applyContextMenuEnabled(optionValue) {
+    if (optionValue) {
+        console.log("Context menu is enabled");
+        // Call the logic to enable the context menu
+        browser.runtime.sendMessage({ action: "enableContextMenu" });
+    } else {
+        console.log("Context menu is disabled");
+        // Call the logic to disable the context menu
+        browser.runtime.sendMessage({ action: "disableContextMenu" });
+    }
+}
+
+/**
+ * Event listener to save the checkbox state and apply it.
+ */
+document.getElementById('contextMenuEnabled').addEventListener('change', async (event) => {
+    const isChecked = event.target.checked;
+    await browser.storage.local.set({ contextMenuEnabled: isChecked });
+
+    // Apply the context menu based on the checkbox state
+    applyContextMenuEnabled(isChecked);
+});
+
+/**
  * Adjust UI if QR code size option is changed.
  *
  * @function
@@ -253,6 +284,10 @@ export function registerTrigger() {
     AutomaticSettings.Trigger.registerSave("qrColor", applyQrCodeColors);
     AutomaticSettings.Trigger.registerSave("qrBackgroundColor", applyQrCodeColors);
     AutomaticSettings.Trigger.registerSave("qrQuietZone", updateQrQuietZoneStatus);
+
+    // Register trigger for contextMenuEnabled
+    AutomaticSettings.Trigger.registerSave("contextMenuEnabled", applyContextMenuEnabled);
+    AutomaticSettings.Trigger.registerUpdate("contextMenuEnabled", applyContextMenuEnabled);
 
     AutomaticSettings.Trigger.registerUpdate("qrColor", applyQrCodeColors);
     AutomaticSettings.Trigger.registerUpdate("qrBackgroundColor", applyQrCodeColors);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -64,6 +64,15 @@
 							<span class="helper-text" data-i18n="__MSG_optionPopupIconColoredDescr__">Shows a colored icon instead of the black/white icon in the toolbar.</span>
 						</div>
 					</li>
+					<li>
+						<div class="line">
+							<input class="setting save-on-change" type="checkbox" id="contextMenuEnabled" name="contextMenuEnabled">
+							<label for="contextMenuEnabled">Enable QR code context menu item</label>							
+						</div>
+						<div class="line indent">
+							<span class="helper-text">Show context menu item to create QR code for the current page.</span>
+						</div>
+					</li>
 				</ul>
 			</section>
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -67,10 +67,10 @@
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="contextMenuEnabled" name="contextMenuEnabled">
-							<label for="contextMenuEnabled">Enable QR code context menu item</label>							
+							<label data-i18n="__MSG_optionContextMenuEnabled__" for="contextMenuEnabled">Show general QR code generation context menu item</label>							
 						</div>
 						<div class="line indent">
-							<span class="helper-text">Show context menu item to create QR code for the current page.</span>
+							<span class="helper-text" data-i18n="__MSG_optionContextMenuEnabledDescr__">Shows a context menu item to create QR code for the current page, in addition to links and text selections.</span>
 						</div>
 					</li>
 				</ul>


### PR DESCRIPTION
This PR adds a context-menu item to generate a QR code for the current page URL. The functionality is implemented in the ContextMenu.js module, and a new message string was added to messages.json for localization.
Resolves issue #321.
