### PR TITLE
Allowed extension to use clipboard content to generate QR code when permission given

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "src/common/modules/CommonCss"]
 	path = src/common/modules/CommonCss
 	url = https://github.com/TinyWebEx/CommonCss
+[submodule "src/common/modules/PermissionRequest"]
+	path = src/common/modules/PermissionRequest
+	url = https://github.com/TinyWebEx/PermissionRequest

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -16,6 +16,7 @@
 - Metta Ong ([@ongspxm](https://github.com/ongspxm))
 - Michael Corwin ([@mcorwin22](https://github.com/mcorwin22))
 - Pradyumna Mahajan ([@pradyumnamahajan](https://github.com/pradyumnamahajan))
+- Mahmoud Ayesh ([@mahmoudhusam](https://github.com/mahmoudhusam))
 
 ## Translators
 

--- a/assets/texts/en/Changelog/next.md
+++ b/assets/texts/en/Changelog/next.md
@@ -1,1 +1,2 @@
+* **New:** An option for using the clipboard content when opening the popup has been added, thanks [@BrandonTuTwo2](https://github.com/BrandonTuTwo2)
 * **New:** The translation for Urdu has been added, thanks to [@Toprun123](https://github.com/Toprun123).

--- a/assets/texts/en/Changelog/next.md
+++ b/assets/texts/en/Changelog/next.md
@@ -1,0 +1,1 @@
+* **New:** The translation for Urdu has been added, thanks to [@Toprun123](https://github.com/Toprun123).

--- a/assets/texts/es/amoSummary.txt
+++ b/assets/texts/es/amoSummary.txt
@@ -1,3 +1,3 @@
-Esta extensión te permite generar rápidamente códigos QR offline de una URL abierta en tus pestañas o cualquier texto (seleccionado)! 👍
+Esta extensión te permite generar rápidamente un código QR con la URL de la pestaña actual, ¡o con cualquier otro texto! 👍
 
-Funciona completamente offline protegiendo así tu privacidad[TOO LONG: y cuenta con un vasto rango de funciones incluyendo la opción de colorear tus códigos QR]!
+Funciona completamente offline, protegiendo así tu privacidad.

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -55,7 +55,8 @@
     "menus"
   ],
   "optional_permissions": [
-    "downloads"
+    "downloads",
+    "clipboardRead"
   ],
   "applications": {
     "gecko": {

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -54,7 +54,8 @@
     "menus"
   ],
   "optional_permissions": [
-    "downloads"
+    "downloads",
+    "clipboardRead"
   ],
   "applications": {
     "gecko": {

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -50,6 +50,10 @@
     "message": "Konnte Optionen nicht zurück setzen!",
     "description": "The message shown, when the options of the settings could not have been reset."
   },
+  "permissionRequiredClipboardRead": {
+    "message": "Die Berechtigung Daten in die Zwischenablage zu kopieren, wird für diese Funktionalität benötigt.",
+    "description": "The message shown, when the user wants to use the clipboard to read from"
+  },
 
   // errors or other messages
   "unknownError": {
@@ -254,7 +258,7 @@
     "description": "This label refers to an option in the add-on settings. It allows users to toggle the visibility of the context menu item for generating a QR code from the current page."
   },
   "optionContextMenuEnabledDescr": {
-    "message": "Zeigt einen Kontextmenü-Eintrag um QR-Codes für die aktuelle Seite zu erstellen, zusätzlich zu denen für Links und ausgewählten Text.",
+    "message": "Zeigt einen Kontextmenü-Eintrag, um QR-Codes für die aktuelle Seite zu erstellen, zusätzlich zu denen für Links und ausgewählten Text.",
     "description": "This is the helper text for the context menu toggle option. It explains that enabling this option will show the QR code generation context menu for the current page."
   },
 
@@ -364,6 +368,11 @@
   },
   "optionUseMonospaceFont": {
     "message": "Benutze Monospace-Schrift",
+    "description": "This is an option shown in the add-on settings."
+  },
+
+  "optionAutoGetClipboardContent": {
+    "message": "Benutze den Inhalt der Zwischenablage wenn der Popup geöffnet wird",
     "description": "This is an option shown in the add-on settings."
   },
 

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -186,6 +186,14 @@
     "message": "&QR-Code aus Link",
     "description": "The context menu entry shown for generating QR codes from a selected link with an access key."
   },
+  "contextMenuItemConvertPageURL": {
+    "message": "Generiere QR-Code für diese Seite",
+    "description": "Context menu item title for generating a QR code for the current page URL."
+  },
+  "contextMenuItemConvertPageURLAccessKey": {
+    "message": "&Generiere QR-Code für diese Seite",
+    "description": "Context menu item title for generating a QR code for the current page URL with an access key."
+  },
   "contextMenuSaveImageCanvas": {
     "message": "QR-Code als Bild speichern…",
     "description": "The context menu entry shown for saving SVG images in the popup."
@@ -240,6 +248,14 @@
   "optionPopupIconColoredDescr": {
     "message": "Zeigt ein farbiges Icon anstatt eines schwarz/weißen Icons in der Toolbar.",
     "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."
+  },
+  "optionContextMenuEnabled": {
+    "message": "Zeige allgemeinen QR-Code-Generierungs-Kontextmenü-Eintrag",
+    "description": "This label refers to an option in the add-on settings. It allows users to toggle the visibility of the context menu item for generating a QR code from the current page."
+  },
+  "optionContextMenuEnabledDescr": {
+    "message": "Zeigt einen Kontextmenü-Eintrag um QR-Codes für die aktuelle Seite zu erstellen, zusätzlich zu denen für Links und ausgewählten Text.",
+    "description": "This is the helper text for the context menu toggle option. It explains that enabling this option will show the QR code generation context menu for the current page."
   },
 
   "subtitleQrCodeSize": {

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -54,6 +54,14 @@
     "message": "Die Berechtigung Daten in die Zwischenablage zu kopieren, wird für diese Funktionalität benötigt.",
     "description": "The message shown, when the user wants to use the clipboard to read from"
   },
+  "buttonRequestPermission": {
+    "message": "Berechtigung erteilen",
+    "description": "The button label, used for requesting a permission that is missing."
+  },
+  "couldNotRequestPermission": {
+    "message": "Konnte Berechtigung nicht erfragen.",
+    "description": "When the permission request fails."
+  },
 
   // errors or other messages
   "unknownError": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -377,6 +377,14 @@
     "message": "Use clipboard content when opening popup",
     "description": "This is an option shown in the add-on settings."
   },
+  "buttonRequestPermission": {
+    "message": "Grant permission",
+    "description": "The button label, used for requesting a permission that is missing."
+  },
+  "couldNotRequestPermission": {
+    "message": "Requesting permission failed.",
+    "description": "When the permission request fails."
+  },
 
   "optionDebugMode": {
     "message": "Enable debug mode",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -190,6 +190,14 @@
     "message": "&QR code from link",
     "description": "The context menu entry shown for generating QR codes from a selected link with an access key."
   },
+  "contextMenuItemConvertPageURL": {
+    "message": "Generate QR code for this page",
+    "description": "Context menu item title for generating a QR code for the current page URL."
+  },
+  "contextMenuItemConvertPageURLAccessKey": {
+    "message": "&Generate QR code for this page",
+    "description": "Context menu item title for generating a QR code for the current page URL with an access key."
+  },
   "contextMenuSaveImageCanvas": {
     "message": "Save QR code as an image…",
     "description": "The context menu entry shown for saving PNG images (from a canvas) in the popup."
@@ -245,6 +253,14 @@
   "optionPopupIconColoredDescr": {
     "message": "Shows a colored icon instead of the black/white icon in the toolbar.",
     "description": "This is an option shown in the add-on settings. It describes the optionPopupIconColored setting in more details."
+  },
+  "optionContextMenuEnabled": {
+    "message": "Show general QR code generation context menu item",
+    "description": "This label refers to an option in the add-on settings. It allows users to toggle the visibility of the context menu item for generating a QR code from the current page."
+  },
+  "optionContextMenuEnabledDescr": {
+    "message": "Shows a context menu item to create QR code for the current page, in addition to links and text selections.",
+    "description": "This is the helper text for the context menu toggle option. It explains that enabling this option will show the QR code generation context menu for the current page."
   },
 
   "subtitleQrCodeSize": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -50,6 +50,10 @@
     "message": "Could not reset options!",
     "description": "The message shown, when the options of the settings could not have been reset."
   },
+  "permissionRequiredClipboardRead": {
+    "message": "The permission to copy data from the clipboard is required for this feature.",
+    "description": "The message shown, when the user wants to use the clipboard to read from"
+  },
 
   // errors or other messages
   "unknownError": {
@@ -350,6 +354,11 @@
   },
   "optionUseMonospaceFont": {
     "message": "Use monospace font",
+    "description": "This is an option shown in the add-on settings."
+  },
+
+  "optionAutoGetClipboardContent": {
+    "message": "Use clipboard content when opening popup",
     "description": "This is an option shown in the add-on settings."
   },
 

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -4,6 +4,7 @@ import { createMenu } from "/common/modules/ContextMenu.js";
 const CONVERT_TEXT_SELECTION = "qr-convert-text-selection";
 const CONVERT_LINK_TEXT_SELECTION = "qr-convert-link-text-selection";
 const OPEN_OPTIONS = "qr-open-options";
+const CONVERT_PAGE_URL = "qr-convert-page-url";
 
 const MESSAGE_RESENT_TIMEOUT = 200; // ms
 const MESSAGE_RESENT_MAX = 9;
@@ -55,12 +56,17 @@ function createItems() {
         contexts: ["link"]
     });
 
+    const pageMenu = createMenu("contextMenuItemConvertPageURL", {
+        id: CONVERT_PAGE_URL,
+        contexts: ["page"]
+    });
+
     browser.menus.refresh();
 
     // if listener is set, because items were hidden -> remove it
     browser.menus.onHidden.removeListener(createItems);
 
-    return Promise.all([selectionMenu, linkMenu]);
+    return Promise.all([selectionMenu, linkMenu, pageMenu]);
 }
 
 /**
@@ -86,6 +92,13 @@ function menuClicked(event) {
 
             // send message to popup
             sendQrCodeText(event.linkUrl);
+        });
+        break;
+    case CONVERT_PAGE_URL:
+        browser.browserAction.openPopup().then(() => {
+            messageResentCount = 0;
+            // Send the current page URL to the popup explicitly to overwrite any setting that may use a different string
+            sendQrCodeText(event.pageUrl);
         });
         break;
     case OPEN_OPTIONS:
@@ -119,6 +132,7 @@ function menuShown(info) {
 
     browser.menus.remove(CONVERT_TEXT_SELECTION);
     browser.menus.remove(CONVERT_LINK_TEXT_SELECTION);
+    browser.menus.remove(CONVERT_PAGE_URL);
 
     browser.menus.refresh();
 }
@@ -135,5 +149,15 @@ export function init() {
     return createItems().then(() => {
         browser.menus.onClicked.addListener(menuClicked);
         browser.menus.onShown.addListener(menuShown);
+        browser.runtime.onMessage.addListener((message) => {
+            if (message.action === "enableContextMenu") {
+                browser.menus.update(CONVERT_PAGE_URL, { visible: true });
+                console.log("Context menu enabled");
+            } else if (message.action === "disableContextMenu") {
+                browser.menus.update(CONVERT_PAGE_URL, { visible: false });
+                console.log("Context menu disabled");
+            }
+            browser.menus.refresh();
+        });    
     });
 }

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -20,6 +20,7 @@ const defaultSettings = Object.freeze({
     qrColor: "#0c0c0d",
     qrBackgroundColor: (isDarkTheme ? "#d7d7db" : "#ffffff"), // dark uses Firefox Photon's grey-30
     qrErrorCorrection: "Q",
+    autoGetClipboardContent: false,
     autoGetSelectedText: false,
     monospaceFont: false,
     qrCodeSize: {

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -17,6 +17,7 @@ const isDarkTheme = window.matchMedia("(prefers-color-scheme: dark)").matches;
 const defaultSettings = Object.freeze({
     debugMode: false,
     popupIconColored: false,
+    contextMenuEnabled: true,
     qrColor: "#0c0c0d",
     qrBackgroundColor: (isDarkTheme ? "#d7d7db" : "#ffffff"), // dark uses Firefox Photon's grey-30
     qrErrorCorrection: "Q",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -55,7 +55,8 @@
     "menus"
   ],
   "optional_permissions": [
-    "downloads"
+    "downloads",
+    "clipboardRead"
   ],
   "applications": {
     "gecko": {

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -67,8 +67,6 @@ function applyQrCodeSize(optionValue) {
     }
 }
 
-
-
 /**
  * Adjust UI if QR code size option is changed.
  *
@@ -258,11 +256,11 @@ function applyQrCodeColors(optionValue, option) {
  * @returns {void}
  */
 function resetOnBeforeLoad() {
+    // needs to enable the QR code size input, as a disabled input would prevent the setting from being loaded
+    //
     const elQrCodeSize = document.getElementById("qrCodeSizeFixedValue");
     elQrCodeSize.removeAttribute("disabled");
 }
-
-
 
 /**
  * Adjust options page when copy from clipboard is changed

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -265,6 +265,16 @@ function resetOnBeforeLoad() {
     elQrCodeSize.removeAttribute("disabled");
 }
 
+
+
+/**
+ * Adjust options page when copy from clipboard is changed
+ *
+ * @private
+ * @param  {Boolean} optionValue
+ * @param  {Object} [event]
+ * @returns {Promise}
+ */
 function applyClipboardContent(optionValue, event={}) {
     if (optionValue && !PermissionRequest.isPermissionGranted(CLIPBOARD_READ_PERMISSION)) {
         return PermissionRequest.requestPermission(

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -67,6 +67,31 @@ function applyQrCodeSize(optionValue) {
     }
 }
 
+
+
+
+
+
+/**
+ * Adjusts UI based on the state of context menu enabled option.
+ *
+ * @function
+ * @private
+ * @param {boolean} optionValue
+ * @returns {void}
+ */
+function applyContextMenuEnabled(optionValue) {
+    if (optionValue) {
+        console.log("Context menu is enabled");
+        // Call the logic to enable the context menu
+        browser.runtime.sendMessage({ action: "enableContextMenu" });
+    } else {
+        console.log("Context menu is disabled");
+        // Call the logic to disable the context menu
+        browser.runtime.sendMessage({ action: "disableContextMenu" });
+    }
+}
+
 /**
  * Adjust UI if QR code size option is changed.
  *
@@ -275,6 +300,10 @@ export async function registerTrigger() {
     AutomaticSettings.Trigger.registerSave("qrBackgroundColor", applyQrCodeColors);
     AutomaticSettings.Trigger.registerSave("qrQuietZone", updateQrQuietZoneStatus);
     AutomaticSettings.Trigger.registerSave("autoGetClipboardContent", applyClipboardContent);
+
+    // Register trigger for contextMenuEnabled
+    AutomaticSettings.Trigger.registerSave("contextMenuEnabled", applyContextMenuEnabled);
+    AutomaticSettings.Trigger.registerUpdate("contextMenuEnabled", applyContextMenuEnabled);
 
     AutomaticSettings.Trigger.registerUpdate("qrColor", applyQrCodeColors);
     AutomaticSettings.Trigger.registerUpdate("qrBackgroundColor", applyQrCodeColors);

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -69,7 +69,6 @@ function applyQrCodeSize(optionValue) {
 
 
 
-
 /**
  * Adjust UI if QR code size option is changed.
  *
@@ -259,8 +258,6 @@ function applyQrCodeColors(optionValue, option) {
  * @returns {void}
  */
 function resetOnBeforeLoad() {
-    // needs to enable the QR code size input, as a disabled input would prevent the setting from being loaded
-    //
     const elQrCodeSize = document.getElementById("qrCodeSizeFixedValue");
     elQrCodeSize.removeAttribute("disabled");
 }
@@ -282,7 +279,7 @@ function applyClipboardContent(optionValue, event={}) {
             MESSAGE_CLIPBOARD_READ_PERMISSION,
             event,
             {retry: true}
-        )
+        );
     } 
     PermissionRequest.cancelPermissionPrompt(CLIPBOARD_READ_PERMISSION,MESSAGE_CLIPBOARD_READ_PERMISSION);
     return Promise.resolve();

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -16,6 +16,9 @@ import * as IconHandler from "/common/modules/IconHandler.js";
 
 const REMEBER_SIZE_INTERVAL = 500; // sec
 const CONTRAST_MESSAGE_ID = "contrast";
+const CLIPBOARD_READ_PERMISSION = {
+    permissions: ["clipboardRead"]
+};
 
 let updateRemberedSizeInterval = null;
 

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -243,10 +243,7 @@ function resetOnBeforeLoad() {
 }
 
 function applyClipboardContent(optionValue, event={}) {
-    if (optionValue.enabled && // only if actually enabled
-        optionValue.action === "copy" && // if we require a permission for copying
-        !PermissionRequest.isPermissionGranted(CLIPBOARD_READ_PERMISSION) // and not already granted
-    ) {
+    if (optionValue && !PermissionRequest.isPermissionGranted(CLIPBOARD_READ_PERMISSION)) {
         return PermissionRequest.requestPermission(
             CLIPBOARD_READ_PERMISSION,
             MESSAGE_CLIPBOARD_READ_PERMISSION,
@@ -255,8 +252,6 @@ function applyClipboardContent(optionValue, event={}) {
         )
     } 
     PermissionRequest.cancelPermissionPrompt(CLIPBOARD_READ_PERMISSION,MESSAGE_CLIPBOARD_READ_PERMISSION);
-    
-
     return Promise.resolve();
 } 
 

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -70,7 +70,18 @@ function applyQrCodeSize(optionValue) {
 
 
 
-
+/**
+ * Adjust UI if QR code size option is changed.
+ *
+ * @function
+ * @private
+ * @param  {boolean} optionValue
+ * @param  {string} [option]
+ * @returns {void}
+ */
+function applyPopupIconColor(optionValue) {
+    IconHandler.changeIconIfColored(optionValue);
+}
 
 /**
  * Adjusts UI based on the state of context menu enabled option.
@@ -90,19 +101,6 @@ function applyContextMenuEnabled(optionValue) {
         // Call the logic to disable the context menu
         browser.runtime.sendMessage({ action: "disableContextMenu" });
     }
-}
-
-/**
- * Adjust UI if QR code size option is changed.
- *
- * @function
- * @private
- * @param  {boolean} optionValue
- * @param  {string} [option]
- * @returns {void}
- */
-function applyPopupIconColor(optionValue) {
-    IconHandler.changeIconIfColored(optionValue);
 }
 
 /**

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -180,7 +180,7 @@
 							<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
 						</div>
 					</li>
-			
+
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -64,6 +64,15 @@
 							<span class="helper-text" data-i18n="__MSG_optionPopupIconColoredDescr__">Shows a colored icon instead of the black/white icon in the toolbar.</span>
 						</div>
 					</li>
+					<li>
+						<div class="line">
+							<input class="setting save-on-change" type="checkbox" id="contextMenuEnabled" name="contextMenuEnabled">
+							<label data-i18n="__MSG_optionContextMenuEnabled__" for="contextMenuEnabled">Show general QR code generation context menu item</label>							
+						</div>
+						<div class="line indent">
+							<span class="helper-text" data-i18n="__MSG_optionContextMenuEnabledDescr__">Shows a context menu item to create QR code for the current page, in addition to links and text selections.</span>
+						</div>
+					</li>
 				</ul>
 			</section>
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -184,7 +184,7 @@
 							<label data-i18n="__MSG_optionAutoGetClipboardContent__" for="autoGetClipboardContent">Use clipboard content when opening popup</label>
 						</div>
 						<div class="message-container line">
-							<div id="searchActionCopyPermissionInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+							<div id="getClipboardContentPermissionInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
 								<span class="message-text">Permission requested.</span>
 								<a href="#">
 									<button type="button" class="message-action-button micro-button info invisible"></button>

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -180,7 +180,7 @@
 							<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
 						</div>
 					</li>
-					
+			
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -180,6 +180,7 @@
 							<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
 						</div>
 					</li>
+					
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -140,7 +140,7 @@
 						</div>
 					</li>
 
-					<li class="message-container">
+					<li class="line">
 						<div id="messageContrast" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
 							<span class="message-text"></span>
 							<a href="#">
@@ -193,7 +193,7 @@
 							<input class="setting save-on-change" type="checkbox" id="autoGetClipboardContent" name="autoGetClipboardContent">
 							<label data-i18n="__MSG_optionAutoGetClipboardContent__" for="autoGetClipboardContent">Use clipboard content when opening popup</label>
 						</div>
-						<div class="message-container line">
+						<div class="line">
 							<div id="getClipboardContentPermissionInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
 								<span class="message-text">Permission requested.</span>
 								<a href="#">

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -171,7 +171,6 @@
 							<label data-i18n="__MSG_optionAutoGetSelectedText__" for="autoGetSelectedText">Automatically use text selected on website</label>
 						</div>
 					</li>
-
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="monospaceFont" name="monospaceFont">
@@ -179,6 +178,21 @@
 						</div>
 					</li>
 
+					<li>
+						<div class="line">
+							<input class="setting save-on-change" type="checkbox" id="autoGetClipboardContent" name="autoGetClipboardContent">
+							<label data-i18n="__MSG_optionAutoGetClipboardContent__" for="autoGetClipboardContent">Use clipboard content when opening popup</label>
+						</div>
+						<div class="message-container line">
+							<div id="searchActionCopyPermissionInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+								<span class="message-text">Permission requested.</span>
+								<a href="#">
+									<button type="button" class="message-action-button micro-button info invisible"></button>
+								</a>
+								<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+							</div>
+						</div>
+					</li>
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="debugMode" name="debugMode">

--- a/src/popup/modules/InitQrCode.js
+++ b/src/popup/modules/InitQrCode.js
@@ -56,6 +56,24 @@ const gettingSelection = AddonSettings.get("autoGetSelectedText").then((autoGetS
     });
 });
 
+// check for clipboard text
+const gettingClipboard = AddonSettings.get("autoGetClipboardContent").then((autoGetClipboardContent) => {
+    if (autoGetClipboardContent !== true) {
+        return Promise.reject(new Error("using clipboard content is disabled"));
+    }
+
+    navigator.clipboard.readText().then(text => {
+        if (text && text !== "") {
+            return Promise.resolve(text);
+        } else {
+            return Promise.reject(new Error("clipboard is empty")); 
+        }
+    }).catch(err => {
+        return Promise.reject(err);
+    })
+});
+
+
 // generate QR code from tab or selected text or message, if everything is set up
 export const initiationProcess = Promise.all([qrCreatorInit, userInterfaceInit]).then(() => {
     // do not use tab URL as text if text is already overwritten

--- a/src/popup/modules/InitQrCode.js
+++ b/src/popup/modules/InitQrCode.js
@@ -93,18 +93,29 @@ export const initiationProcess = Promise.all([qrCreatorInit, userInterfaceInit])
             UserInterface.handleQrError(e);
         }
     }).catch(() => {
-        // …or fallback to tab URL
-        return queryBrowserTabs.then(QrCreator.generateFromTabs)
-            .catch(UserInterface.handleQrError)
-            .catch((error) => {
-                console.error(error);
+        // try getting text from the clipboard
+        return gettingClipboard.then((clipboard) => {
+            try {
+                QrCreator.setText(clipboard);
+                QrCreator.generate();
+                UserInterface.postInitGenerate();
+            } catch (e) {
+                UserInterface.handleQrError(e);
+            }
+        }).catch(() => {
+            // …or fallback to tab URL
+            return queryBrowserTabs.then(QrCreator.generateFromTabs)
+                .catch(UserInterface.handleQrError)
+                .catch((error) => {
+                    console.error(error);
 
-                // show generic error, likely a tab URL error
-                CommonMessages.showError("couldNotReceiveActiveTab", false);
+                    // show generic error, likely a tab URL error
+                    CommonMessages.showError("couldNotReceiveActiveTab", false);
 
-                // re-throw error
-                throw error;
-            });
+                    // re-throw error
+                    throw error;
+                }); 
+        });
     });
 }).finally(() => {
     // post-initiation code should still run, even if errors happen

--- a/src/popup/modules/InitQrCode.js
+++ b/src/popup/modules/InitQrCode.js
@@ -59,7 +59,8 @@ const gettingSelection = AddonSettings.get("autoGetSelectedText").then((autoGetS
     });
 });
 
-// check for clipboard text
+// check for clipboard text if option is enabled and if extension has permission to read from clipboard
+// if the clipboard is empty it rejects the promise
 const gettingClipboard = AddonSettings.get("autoGetClipboardContent").then((autoGetClipboardContent) => {
     if (autoGetClipboardContent !== true || !browser.permissions.contains(CLIPBOARD_READ_PERMISSION)) {
         return Promise.reject(new Error("using clipboard content is disabled"));

--- a/src/popup/modules/InitQrCode.js
+++ b/src/popup/modules/InitQrCode.js
@@ -30,6 +30,10 @@ const userInterfaceInit = UserInterface.init().then(() => {
     console.info("UserInterface module loaded.");
 });
 
+const CLIPBOARD_READ_PERMISSION = {
+    permissions: ["clipboardRead"]
+};
+
 // check for selected text
 // current tab is used by default
 const gettingSelection = AddonSettings.get("autoGetSelectedText").then((autoGetSelectedText) => {
@@ -51,18 +55,17 @@ const gettingSelection = AddonSettings.get("autoGetSelectedText").then((autoGetS
         if (!selection) {
             throw new Error("nothing selected");
         }
-
         return selection;
     });
 });
 
 // check for clipboard text
 const gettingClipboard = AddonSettings.get("autoGetClipboardContent").then((autoGetClipboardContent) => {
-    if (autoGetClipboardContent !== true) {
+    if (autoGetClipboardContent !== true || !browser.permissions.contains(CLIPBOARD_READ_PERMISSION)) {
         return Promise.reject(new Error("using clipboard content is disabled"));
     }
 
-    navigator.clipboard.readText().then(text => {
+    return navigator.clipboard.readText().then((text) => {
         if (text && text !== "") {
             return Promise.resolve(text);
         } else {
@@ -82,7 +85,6 @@ export const initiationProcess = Promise.all([qrCreatorInit, userInterfaceInit])
 
         return Promise.resolve();
     }
-
     // get text from selected text, if possible
     return gettingSelection.then((selection) => {
         try {

--- a/src/popup/modules/InitQrCode.js
+++ b/src/popup/modules/InitQrCode.js
@@ -74,7 +74,7 @@ const gettingClipboard = AddonSettings.get("autoGetClipboardContent").then((auto
         }
     }).catch(err => {
         return Promise.reject(err);
-    })
+    });
 });
 
 


### PR DESCRIPTION
PR for this issue https://github.com/rugk/offline-qr-code/issues/282. Allows the user to create QR codes from copied text from the clipboard granted they give permission to allow the extension to read from the clipboard and turn the setting on. If the clipboard is empty defaults the current tabs URL

