### PR TITLE
add button to copy qrCode text

### DIFF
--- a/src/popup/modules/UserInterface.js
+++ b/src/popup/modules/UserInterface.js
@@ -43,6 +43,7 @@ const qrCodePlaceholder = document.getElementById("qrcode-placeholder");
 const qrCodeContainer = document.getElementById("qrcode-container");
 const qrCodeResizeContainer = document.getElementById("qrcode-resize-container");
 const qrCodeText = document.getElementById("qrcodetext");
+document.getElementById("copy-qr-btn").addEventListener("click", copyToClipboard); //copy text button
 
 let resizeMutationObserver;
 
@@ -52,6 +53,33 @@ let placeholderShown = true;
 let qrLastSize = 200;
 let qrCodeSizeOption = {};
 let savingQrCodeSize = null; // promise
+
+/**
+ * Copy text of text area in clipboard when 
+ * button is pressed
+ *
+ * @function
+ * @returns {void}
+ */
+async function copyToClipboard() {
+    try {
+        await navigator.clipboard.writeText(qrCodeText.value);
+        
+        const copyStatus = document.getElementById("copy-status");
+        copyStatus.textContent = "Text copied";
+
+        //add styling for message status
+        copyStatus.classList.add("show");
+
+        //after 1sec status message is not displayed anymore
+        setTimeout(() => {
+            copyStatus.classList.remove("show");
+        }, 1300);
+    } catch (error) {
+        console.error("Error during copy :", error);
+    }
+}
+
 
 /**
  * Hide QR code and show placeholder instead.

--- a/src/popup/qrcode.css
+++ b/src/popup/qrcode.css
@@ -125,3 +125,34 @@ html, body {
     color: var(--white-100);
   }
 }
+
+/* Copy button  */
+.copy-container{
+  margin: 5px 0;
+}
+
+.copy-container{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+/* Copy status message  */
+#copy-status{
+  display: none;
+  position: absolute;
+  top: -6px;
+  color: black;
+  background-color: white;
+  padding: 2px;
+  border-radius: 2px;
+  transition: opacity 0.5s ease;
+}
+
+/* copy status message when status is shwon */
+#copy-status.show{
+  display: block;
+  opacity: 1;
+
+}
+

--- a/src/popup/qrcode.html
+++ b/src/popup/qrcode.html
@@ -52,6 +52,11 @@
 					placeholder="Enter text for QR code here to generate it."
 					autofocus="true"
 					data-i18n
-					data-i18n-placeholder="__MSG_textareaPlaceholder__"></textarea>
+					data-i18n-placeholder="__MSG_textareaPlaceholder__">
+		</textarea>
+		<div class="copy-container">
+			<button id="copy-qr-btn">Copy text</button>
+			<p id="copy-status">Text copied!</p>
+		</div>
 	</body>
 </html>


### PR DESCRIPTION
I’ve added a button that allows users to copy the text generated for the QR code. When the text is successfully copied, a message will appear to confirm the action. This is my first contribution

You can find the changes below:

<img width="257" alt="Capture d’écran 2024-11-04 à 12 41 44" src="https://github.com/user-attachments/assets/1c53964a-8c0c-40df-856a-8277a7b7ffd8">
<img width="260" alt="Capture d’écran 2024-11-04 à 12 42 30" src="https://github.com/user-attachments/assets/5e0dfaf3-074a-4142-b17b-56c27181a955">
