### PR TITLE
Add qr code size warning on too large QR code

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -108,6 +108,10 @@
     "message": "Use contrasting color",
     "description": "The text of a button that sets a new color with a sufficient contrast."
   },
+  "qrCodeSizeTooLargeWarning": {
+    "message": "The selected QR code size exceeds the available display space. The displayed QR code will be resized to fit. ",
+    "description": "The message shown when the requested QR code size is too large to display and has been automatically scaled down to fit."
+  },
 
   // tips
   "tipYouLikeAddon": {

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -109,7 +109,7 @@
     "description": "The text of a button that sets a new color with a sufficient contrast."
   },
   "qrCodeSizeTooLargeWarning": {
-    "message": "The selected QR code size exceeds the available display space. The displayed QR code will be resized to fit. ",
+    "message": "The selected QR code size exceeds the available display space. The displayed QR code has been resized to fit. ",
     "description": "The message shown when the requested QR code size is too large to display and has been automatically scaled down to fit."
   },
 

--- a/src/popup/qrcode.html
+++ b/src/popup/qrcode.html
@@ -41,6 +41,10 @@
 						<span class="message-text" data-i18n="__MSG_couldNotGenerateQrCode__">Could not generate QR code.</span>
 						<img class="icon-dismiss invisible" src="/common/img/close-white.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
 					</div>
+					<div id="messageWarning" aria-label="warning message" data-i18n data-i18n-aria-label="__MSG_ariaMessageWarning__" class="message-box warning float-qr float-qr-bottom invisible fade-hide">
+						<span class="message-text"></span>
+						<img class="icon-dismiss invisible" src="/common/img/close-white.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+					</div>
 					<div id="messageLoading" aria-label="loading message" data-i18n data-i18n-aria-label="__MSG_ariaMessageLoading__" class="message-box info float-qr float-qr-bottom">
 						<span class="message-text" data-i18n="__MSG_loading__">Loading…</span>
 					</div>


### PR DESCRIPTION
Pull Request that Closes: #35 

A warning message was added if the fixed qr size is too large to be shown in the maximum dimensions of a firefox popup window (800x600), see screenshot 1. This message does not show on mobile platforms . The warning can be dismissed and is automatically hidden if users manually resize the popup.

Furthermore, when trying large fixed sizes to find overflowing QR Codes, I ran into the issue that when the fixed size is large, e.g. 1000, the initial centering of the QR Code is wrong. (screenshot 2)
I was able to fix this by using the resizeLayout function in the initialization. 

1) 
![image](https://github.com/user-attachments/assets/860d92d2-9128-4446-bea9-8ab81051c001)

2)
![image](https://github.com/user-attachments/assets/78918edb-dab8-4bd2-ada2-982f2f950e0e)

