### PR TITLE
Move resize handle to lower left

### DIFF
--- a/src/popup/modules/UserInterface.js
+++ b/src/popup/modules/UserInterface.js
@@ -554,7 +554,7 @@ async function createContextMenu() {
 export function lateInit() {
     // start listening for resize events very late, so that it does not
     // conflict with restoring the popup size
-    resizeMutationObserver.observe(qrCodeText, {
+    resizeMutationObserver.observe(document.body, {
         attributes: true,
         attributeFilter: ["style"]
     });

--- a/src/popup/qrcode.css
+++ b/src/popup/qrcode.css
@@ -8,6 +8,16 @@ html, body {
   max-height: 100%;
   height: 100%;
 }
+
+body {
+  direction: rtl;
+  resize: both;
+}
+
+body > * {
+  direction: __MSG_@@bidi_dir__;
+}
+
 /* on (small) mobile displays */
 @media (max-width: 700px) {
   body {
@@ -103,7 +113,7 @@ html, body {
   min-height: 2em;
   max-height: 100%;
 
-  resize: both;
+  resize: none;
 
   /* Firefox needs a fixed height, so it can scale the popup large enough when QR code is displayed */
   height: 6em;


### PR DESCRIPTION
### Problem:

In LTR locales, the resize handle sits in the lower right of the popup. The right edge of the popup is fixed below the extension icon, so that edge can't move. When the handle is dragged, the popup grows from the left instead, which is disorienting.

### Solution:

Move the resize handle to the lower left, so it's on the edge that actually moves.

### Implementation:

The resize handle is a property of the textarea, and it is placed in the lower left automatically when the element's direction is RTL. We don't want to flip the direction on the textarea itself, since user-entered text should display in its natural reading direction.

So this PR:

- Moves the resize handle from the textarea to the body.
- Sets `direction: rtl` on the body (so the handle ends up on the left).
- Sets `direction: __MSG_@@bidi_dir__` on the body's children, so content still respects the user's locale. `__MSG_@@bidi_dir__` is copied from [CommonCss](https://github.com/TinyWebEx/CommonCss/blob/f661621dee2adb8aeb61f20379365f54464bb03d/common.css#L4).
- Updates `resizeMutationObserver` to observe the body instead of the textarea, since the body is now what resizes.