### PR TITLE
fix(contextMenu): use BrowserCommunication to fix exception in it's receiver

### DIFF
--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -151,7 +151,7 @@ export function init() {
         browser.menus.onClicked.addListener(menuClicked);
         browser.menus.onShown.addListener(menuShown);
 
-        BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.SET_QR_TEXT, (request, sender, sendResponse) => {
+        BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.SET_QR_TEXT, (request) => {
             if (request.value) {
                 browser.menus.update(CONVERT_PAGE_URL, { visible: true });
                 console.log("Context menu enabled");
@@ -159,8 +159,6 @@ export function init() {
                 browser.menus.update(CONVERT_PAGE_URL, { visible: false });
                 console.log("Context menu disabled");
             }
-
-            sendResponse();
         });
     });
 }

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -1,4 +1,3 @@
-
 import * as BrowserCommunication from "/common/modules/BrowserCommunication/BrowserCommunication.js";
 import { COMMUNICATION_MESSAGE_TYPE } from "/common/modules/data/BrowserCommunicationTypes.js";
 import { createMenu } from "/common/modules/ContextMenu.js";

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -1,3 +1,5 @@
+
+import * as BrowserCommunication from "/common/modules/BrowserCommunication/BrowserCommunication.js";
 import { COMMUNICATION_MESSAGE_TYPE } from "/common/modules/data/BrowserCommunicationTypes.js";
 import { createMenu } from "/common/modules/ContextMenu.js";
 
@@ -149,15 +151,17 @@ export function init() {
     return createItems().then(() => {
         browser.menus.onClicked.addListener(menuClicked);
         browser.menus.onShown.addListener(menuShown);
-        browser.runtime.onMessage.addListener((message) => {
-            if (message.action === "enableContextMenu") {
+
+        BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.SET_QR_TEXT, (request, sender, sendResponse) => {
+            if (request.value) {
                 browser.menus.update(CONVERT_PAGE_URL, { visible: true });
                 console.log("Context menu enabled");
-            } else if (message.action === "disableContextMenu") {
+            } else {
                 browser.menus.update(CONVERT_PAGE_URL, { visible: false });
                 console.log("Context menu disabled");
             }
-            browser.menus.refresh();
-        });    
+
+            sendResponse();
+        });
     });
 }

--- a/src/common/modules/data/BrowserCommunicationTypes.js
+++ b/src/common/modules/data/BrowserCommunicationTypes.js
@@ -13,5 +13,6 @@
 export const COMMUNICATION_MESSAGE_TYPE = Object.freeze({
     SET_QR_TEXT: "setQrText",
     SAVE_FILE_AS: "saveFileAs",
-    SAVE_FILE_AS_STOP_RETRY: "saveFileAsStopRetry"
+    SAVE_FILE_AS_STOP_RETRY: "saveFileAsStopRetry",
+    CONTEXT_MENU_CHANGE: "contextMenuChange"
 });

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -10,6 +10,7 @@ import * as CommonMessages from "/common/modules/MessageHandler/CommonMessages.j
 import * as CustomMessages from "/common/modules/MessageHandler/CustomMessages.js";
 import { MESSAGE_LEVEL } from "/common/modules/data/MessageLevel.js";
 import * as PermissionRequest from "/common/modules/PermissionRequest/PermissionRequest.js";
+import { COMMUNICATION_MESSAGE_TYPE } from "/common/modules/data/BrowserCommunicationTypes.js";
 
 // used to apply options
 import * as Colors from "/common/modules/Colors.js";
@@ -89,15 +90,10 @@ function applyPopupIconColor(optionValue) {
  * @returns {void}
  */
 function applyContextMenuEnabled(optionValue) {
-    if (optionValue) {
-        console.log("Context menu is enabled");
-        // Call the logic to enable the context menu
-        browser.runtime.sendMessage({ action: "enableContextMenu" });
-    } else {
-        console.log("Context menu is disabled");
-        // Call the logic to disable the context menu
-        browser.runtime.sendMessage({ action: "disableContextMenu" });
-    }
+    browser.runtime.sendMessage({
+        type: COMMUNICATION_MESSAGE_TYPE.SET_QR_TEXT,
+        value: optionValue
+    });
 }
 
 /**
@@ -278,10 +274,10 @@ function applyClipboardContent(optionValue, event={}) {
             event,
             {retry: true}
         );
-    } 
+    }
     PermissionRequest.cancelPermissionPrompt(CLIPBOARD_READ_PERMISSION,MESSAGE_CLIPBOARD_READ_PERMISSION);
     return Promise.resolve();
-} 
+}
 
 /**
  * Binds the triggers.


### PR DESCRIPTION
```
Uncaught (in promise) Error: message type is undefined
    checkMessageTypeVadility moz-extension://3db1c16a-28d7-42cf-8242-9b59e6354f2e/common/modules/BrowserCommunication/BrowserCommunication.js:50
    addListener moz-extension://3db1c16a-28d7-42cf-8242-9b59e6354f2e/common/modules/BrowserCommunication/BrowserCommunication.js:126
    init moz-extension://3db1c16a-28d7-42cf-8242-9b59e6354f2e/background/modules/ContextMenu.js:155
    promise callback*init moz-extension://3db1c16a-28d7-42cf-8242-9b59e6354f2e/background/modules/ContextMenu.js:151
    <anonymous> moz-extension://3db1c16a-28d7-42cf-8242-9b59e6354f2e/background/background.js:9
BrowserCommunication.js:50:15
```